### PR TITLE
Sans alphatims

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -34,6 +34,10 @@ def run_tims_converter(args):
             # Initialize Bruker DLL.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            if schema != 'TDF':
+                logging.warning('.tdf file not detected...')
+                logging.warning('Exiting...')
+                sys.exit(1)
             logging.info(get_timestamp() + ':' + '.tdf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing LC-TIMS-MS data...')
             data = tdf_data(infile, bruker_dll)
@@ -44,6 +48,10 @@ def run_tims_converter(args):
             # Initialize Bruker DLL.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            if schema != 'TSF':
+                logging.warning('.tsf file not detected...')
+                logging.warning('Exiting...')
+                sys.exit(1)
             logging.info(get_timestamp() + ':' + '.tsf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing MALDI dried droplet data...')
             if run_args['maldi_output_file'] == 'individual':
@@ -65,6 +73,10 @@ def run_tims_converter(args):
             # Initialize Bruker DLL.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            if schema != 'TDF':
+                logging.warning('.tdf file not detected...')
+                logging.warning('Exiting...')
+                sys.exit(1)
             logging.info(get_timestamp() + ':' + '.tdf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing MALDI-TIMS dried droplet data...')
             if run_args['maldi_output_file'] == 'individual':
@@ -88,6 +100,10 @@ def run_tims_converter(args):
             # Initialize Bruker DLL.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            if schema != 'TSF':
+                logging.warning('.tsf file not detected...')
+                logging.warning('Exiting...')
+                sys.exit(1)
             logging.info(get_timestamp() + ':' + '.tsf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing MALDI imaging mass spectrometry data...')
             data = tsf_data(infile, bruker_dll)
@@ -97,6 +113,10 @@ def run_tims_converter(args):
             # Initialize Bruker DLL.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            if schema != 'TDF':
+                logging.warning('.tdf file not detected...')
+                logging.warning('Exiting...')
+                sys.exit(1)
             logging.info(get_timestamp() + ':' + '.tdf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing MALDI-TIMS imaging mass spectrometry data...')
             data = tdf_data(infile, bruker_dll)

--- a/bin/run.py
+++ b/bin/run.py
@@ -22,7 +22,10 @@ def run_tims_converter(args):
             run_args['outdir'] = os.path.split(infile)[0]
         # Make output filename the default filename if not specified.
         if run_args['outfile'] == '':
-            run_args['outfile'] = os.path.splitext(os.path.split(infile)[-1])[0] + '.mzML'
+            if run_args['experiment'] in ['lc-tims-ms', 'maldi-dd', 'maldi-tims-dd']:
+                run_args['outfile'] = os.path.splitext(os.path.split(infile)[-1])[0] + '.mzML'
+            elif run_args['experiment'] in ['maldi-ims', 'maldi-tims-ims']:
+                run_args['outfile'] = os.path.splitext(os.path.split(infile)[-1])[0] + '.imzML'
 
         logging.info(get_timestamp() + ':' + 'Reading file: ' + infile)
         schema = schema_detection(infile)

--- a/bin/run.py
+++ b/bin/run.py
@@ -31,14 +31,17 @@ def run_tims_converter(args):
             logging.info(get_timestamp() + ':' + str(key) + ': ' + str(value))
 
         if args['experiment'] == 'lc-tims-ms':
+            # Initialize Bruker DLL.
+            logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
+            bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
+            logging.info(get_timestamp() + ':' + '.tdf file detected...')
             logging.info(get_timestamp() + ':' + 'Processing LC-TIMS-MS data...')
-            data = bruker_to_df(infile)
+            data = tdf_data(infile, bruker_dll)
             write_lcms_mzml(data, infile, run_args['outdir'], run_args['outfile'], run_args['centroid'],
                             run_args['ms2_only'], run_args['ms1_groupby'], run_args['encoding'],
                             run_args['ms2_keep_n_most_abundant_peaks'])
         elif args['experiment'] == 'maldi-dd':
             # Initialize Bruker DLL.
-            # Only initialize if converting MALDI data. LCMS data currently uses AlphaTims.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
             logging.info(get_timestamp() + ':' + '.tsf file detected...')
@@ -60,7 +63,6 @@ def run_tims_converter(args):
                                 run_args['encoding'], run_args['maldi_output_file'], run_args['maldi_plate_map'])
         elif args['experiment'] == 'maldi-tims-dd':
             # Initialize Bruker DLL.
-            # Only initialize if converting MALDI data. LCMS data currently uses AlphaTims.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
             logging.info(get_timestamp() + ':' + '.tdf file detected...')
@@ -84,7 +86,6 @@ def run_tims_converter(args):
                                 run_args['encoding'], run_args['maldi_output_file'], run_args['maldi_plate_map'])
         elif args['experiment'] == 'maldi-ims':
             # Initialize Bruker DLL.
-            # Only initialize if converting MALDI data. LCMS data currently uses AlphaTims.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
             logging.info(get_timestamp() + ':' + '.tsf file detected...')
@@ -94,7 +95,6 @@ def run_tims_converter(args):
                                   run_args['imzml_mode'], run_args['centroid'])
         elif args['experiment'] == 'maldi-tims-ims':
             # Initialize Bruker DLL.
-            # Only initialize if converting MALDI data. LCMS data currently uses AlphaTims.
             logging.info(get_timestamp() + ':' + 'Initialize Bruker .dll file...')
             bruker_dll = init_bruker_dll(BRUKER_DLL_FILE_NAME)
             logging.info(get_timestamp() + ':' + '.tdf file detected...')

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -177,9 +177,11 @@ class tdf_data(object):
         self.framemsmsinfo = None
         self.precursors = None
         self.source_file = bruker_d_folder_name
+        self.mobility_values = None
 
         self.get_global_metadata()
         self.get_frames_table()
+        self.get_mobility_values()
 
         if 'MaldiApplicationType' in self.meta_data.keys():
             self.get_maldiframeinfo_table()
@@ -392,6 +394,17 @@ class tdf_data(object):
 
         return (np.array(new_mz_array, dtype=encoding_dtype),
                 np.array(new_intensity_array, dtype=encoding_dtype))
+
+    # Get mobility values. Implementation from AlphaTims.
+    def get_mobility_values(self):
+        max_num_scans = max(self.frames['NumScans']) + 1
+        indices = np.arange(max_num_scans).astype(np.float64)
+        self.mobility_values = np.empty_like(indices)
+        self.dll.tims_scannum_to_oneoverk0(self.handle,
+                                           1,  # mobility_estimation_from_frame
+                                           indices.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                           self.mobility_values.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+                                           max_num_scans)
 
     # Gets global metadata table as a dictionary.
     def get_global_metadata(self):

--- a/timsconvert/constants.py
+++ b/timsconvert/constants.py
@@ -50,8 +50,8 @@ SCAN_MODE_CATEGORY = {'ms1': [0],
 
 MSMS_TYPE = {'0': 'MS',
              '2': 'MALDI MS/MS',
-             '8': 'dia-PASEF',
-             '9': 'dda-PASEF'}
+             '8': 'dda-PASEF',
+             '9': 'dia-PASEF'}
 
 MSMS_TYPE_CATEGORY = {'ms1': [0],
                       'ms2': [2, 8, 9]}

--- a/timsconvert/data_input.py
+++ b/timsconvert/data_input.py
@@ -21,10 +21,5 @@ def schema_detection(bruker_dot_d_file):
         return 'TSF'
 
 
-# Read in Bruker .d/.tdf files into dataframe using AlphaTims.
-def bruker_to_df(filename):
-    return alphatims.bruker.TimsTOF(filename)
-
-
 if __name__ == '__main__':
     logger = logging.getLogger(__name__)

--- a/timsconvert/parse_lcms.py
+++ b/timsconvert/parse_lcms.py
@@ -85,6 +85,7 @@ def parse_lcms_tdf(tdf_data, ms1_groupby, centroid, encoding, ms2_only):
                                      'isolation_upper_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
                                      'selected_ion_mz': pasefframemsmsinfo_dict['IsolationMz'],
                                      'selected_ion_intensity': precursor_dict['Intensity'],
+                                     'selected_ion_mobility': precursor_dict['Mobility'],
                                      'charge_state': precursor_dict['Charge'],
                                      'collision_energy': pasefframemsmsinfo_dict['CollisionEnergy'],
                                      'parent_frame': int(precursor_dict['Parent']),
@@ -153,6 +154,7 @@ def parse_lcms_tdf(tdf_data, ms1_groupby, centroid, encoding, ms2_only):
                                      'isolation_upper_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
                                      'selected_ion_mz': pasefframemsmsinfo_dict['IsolationMz'],
                                      'selected_ion_intensity': precursor_dict['Intensity'],
+                                     'selected_ion_mobility': precursor_dict['Mobility'],
                                      'charge_state': precursor_dict['Charge'],
                                      'collision_energy': pasefframemsmsinfo_dict['CollisionEnergy'],
                                      'parent_frame': int(precursor_dict['Parent'])}

--- a/timsconvert/parse_lcms.py
+++ b/timsconvert/parse_lcms.py
@@ -1,248 +1,163 @@
+from timsconvert.constants import *
 from timsconvert.timestamp import *
-import alphatims.bruker
-import alphatims.utils
-import sqlite3
 import numpy as np
-import pandas as pd
-import os
 import sys
-import itertools
 import logging
 
 
-# Function for itertools.groupby() to sort dictionaries based on key.
-def key_func_frames(k):
-    return k['parent_frame']
+def parse_lcms_tdf(tdf_data, ms1_groupby, centroid, encoding, ms2_only):
+    logging.info(get_timestamp() + ':' + 'Parsing LC-TIMS-MS/MS spectra...')
+    list_of_frames_dict = tdf_data.frames.to_dict(orient='records')
+    if tdf_data.pasefframemsmsinfo is not None:
+        list_of_pasefframemsmsinfo_dict = tdf_data.pasefframemsmsinfo.to_dict(orient='records')
+    if tdf_data.precursors is not None:
+        list_of_precursors_dict = tdf_data.precursors.to_dict(orient='records')
+    list_of_parent_scan_dicts = []
+    list_of_product_scan_dicts = []
 
+    for index, row in tdf_data.frames.iterrows():
+        frames_dict = [i for i in list_of_frames_dict if int(i['Id']) == int(row['Id'])][0]
 
-# Function for itertools.groupby() to sort dictionaries based on key.
-def key_func_scans(k):
-    return k['parent_scan']
-
-
-# Parse MS1 spectrum and output to dictionary containing necessary data.
-def parse_lcms_tdf_ms1_scan(scan, frame_num, infile, centroid, ms1_groupby):
-    mz_array = scan['mz_values'].values.tolist()
-    intensity_array = scan['intensity_values'].values.tolist()
-
-    if len(mz_array) != 0 and len(intensity_array) != 0:
-        # Set up .tdf database connection.
-        con = sqlite3.connect(os.path.join(infile, 'analysis.tdf'))
-        # Get polarity.
-        pol_query = 'SELECT * FROM Properties WHERE Frame == ' + str(frame_num)
-        pol_query_df = pd.read_sql_query(pol_query, con)
-        pol_prop_query = 'SELECT * FROM PropertyDefinitions WHERE PermanentName = "Mode_IonPolarity"'
-        pol_prop_query_df = pd.read_sql_query(pol_prop_query, con)
-        pol_prop_id = pol_prop_query_df['Id'].values.tolist()[0]
-        # Close connection to database.
-        con.close()
-        # Property 1229 == Mode_IonPolarity; alternatively maybe use 1098 == TOF_IonPolarity?
-        polarity_value = list(set(pol_query_df.loc[pol_query_df['Property'] == pol_prop_id]['Value'].values.tolist()))
-        if len(polarity_value) == 1:
-            polarity_value = polarity_value[0]
-            if int(polarity_value) == 0:
-                polarity = 'positive scan'
-            elif int(polarity_value == 1):
-                polarity = 'negative scan'
-            else:
-                polarity = None
-        else:
-            polarity = None
-
-        base_peak_index = intensity_array.index(max(intensity_array))
-        scan_dict = {'scan_number': None,
-                     'mz_array': mz_array,
-                     'intensity_array': intensity_array,
-                     'scan_type': 'MS1 spectrum',
-                     'polarity': polarity,
-                     'centroided': centroid,
-                     'retention_time': float(list(set(scan['rt_values_min'].values.tolist()))[0]),
-                     'total_ion_current': sum(intensity_array),
-                     'base_peak_mz': float(mz_array[base_peak_index]),
-                     'base_peak_intensity': float(intensity_array[base_peak_index]),
-                     'ms_level': 1,
-                     'high_mz': float(max(mz_array)),
-                     'low_mz': float(min(mz_array)),
-                     'parent_frame': 0,
-                     'parent_scan': None}
-
-        # Spectrum has single mobility value if grouped by scans (mobility).
         if ms1_groupby == 'scan':
-            mobility = list(set(scan['mobility_values'].values.tolist()))
-            if len(mobility) == 1:
-                scan_dict['mobility'] = mobility[0]
-            scan_dict['parent_scan'] = int(list(set(scan['scan_indices'].values.tolist()))[0])
-        # Spectrum has array of mobility values if grouped by frame (retention time).
-        elif ms1_groupby == 'frame':
-            scan_dict['mobility_array'] = scan['mobility_values']
-        return scan_dict
-    else:
-        return None
-
-
-# Get all MS2 scans. Based in part on alphatims.bruker.save_as_mgf().
-def parse_lcms_tdf_ms2_scans(tdf_data, infile, centroid, ms1_groupby, ms2_keep_n_most_abundant_peaks):
-    # Check to make sure timsTOF object is valid.
-    if tdf_data.acquisition_mode != 'ddaPASEF':
-        return None
-
-    # Set up precursor information and get values for precursor indexing.
-    (spectrum_indptr,
-     spectrum_tof_indices,
-     spectrum_intensity_values) = tdf_data.index_precursors(centroiding_window=0,
-                                                            keep_n_most_abundant_peaks=ms2_keep_n_most_abundant_peaks)
-    mono_mzs = tdf_data.precursors.MonoisotopicMz.values
-    average_mzs = tdf_data.precursors.AverageMz.values
-    charges = tdf_data.precursors.Charge.values
-    charges[np.flatnonzero(np.isnan(charges))] = 0
-    charges = charges.astype(np.int64)
-    rtinseconds = tdf_data.rt_values[tdf_data.precursors.Parent.values]
-    intensities = tdf_data.precursors.Intensity.values
-    mobilities = tdf_data.mobility_values[tdf_data.precursors.ScanNumber.values.astype(np.int64)]
-    parent_frames = tdf_data.precursors.Parent.values
-    parent_scans = np.floor(tdf_data.precursors.ScanNumber.values)
-
-    # Set up .tdf database connection.
-    con = sqlite3.connect(os.path.join(infile, 'analysis.tdf'))
-
-    list_of_scan_dicts = []
-    for index in alphatims.utils.progress_callback(range(1, tdf_data.precursor_max_index)):
-        start = spectrum_indptr[index]
-        end = spectrum_indptr[index + 1]
-
-        # Remove MS2 scan if empty.
-        if tdf_data.mz_values[spectrum_tof_indices[start:end]].size != 0 or spectrum_intensity_values[start:end] != 0:
-            if not np.isnan(mono_mzs[index - 1]):
-                # Get isolation width and collision energy from Properties table in .tdf file.
-                iso_query = 'SELECT * FROM PasefFrameMsMsInfo WHERE Precursor = ' + str(index) +\
-                        ' GROUP BY Precursor, IsolationMz, IsolationWidth, ScanNumBegin, ScanNumEnd'
-                iso_query_df = pd.read_sql_query(iso_query, con)
-                # Check to make sure there's only one hit. Exit with error if not.
-                if iso_query_df.shape[0] != 1:
-                    logging.info(get_timestamp() + ':' + 'PasefFrameMsMsInfo Precursor ' + str(index) +
-                                 ' dataframe has more than one row.')
-                    sys.exit(1)
-                collision_energy = int(iso_query_df['CollisionEnergy'].values.tolist()[0])
-                # note: isolation widths are slightly off from what is given in alphatims dataframes.
-                half_isolation_width = float(iso_query_df['IsolationWidth'].values.tolist()[0]) / 2
-                # Get polarity and activation.
-                pol_query = 'SELECT * FROM PasefFrameMsMsInfo WHERE Precursor = ' + str(index)
-                pol_query_df = pd.read_sql_query(pol_query, con)
-                pol_query_2 = 'SELECT * FROM Properties WHERE Frame BETWEEN ' +\
-                         str(min(pol_query_df['Frame'].values.tolist())) + ' AND ' +\
-                         str(max(pol_query_df['Frame'].values.tolist()))
-                pol_query_df_2 = pd.read_sql_query(pol_query_2, con)
-                pol_prop_query = 'SELECT * FROM PropertyDefinitions WHERE PermanentName = "Mode_IonPolarity"'
-                pol_prop_query_df = pd.read_sql_query(pol_prop_query, con)
-                pol_prop_id = pol_prop_query_df['Id'].values.tolist()[0]
-                # Property 1229 == Mode_IonPolarity; alternatively maybe use 1098 == TOF_IonPolarity?
-                polarity_value = list(set(pol_query_df_2.loc[pol_query_df_2['Property'] == pol_prop_id]['Value'].values.tolist()))
-                if len(polarity_value) == 1:
-                    polarity_value = polarity_value[0]
-                    if int(polarity_value) == 0:
-                        polarity = 'positive scan'
-                    elif int(polarity_value == 1):
-                        polarity = 'negative scan'
-                    else:
-                        polarity = None
-                else:
-                    polarity = None
-                # Property 1584 == MSMS_ActivationMode_Act; alternatively, maybe use 1640 == MSMSAuto_FragmentationMode?
-                '''
-                activation_value = list(set(pol_query_df_2.loc[pol_query_df_2['Property'] == 1584]['Value'].values.tolist()))
-                if len(activation_value) == 1:
-                    activation_value = activation_value[0]
-                    if int(activation_value) == 0:
-                        if int(collision_energy) <= 1000:
-                            activation = 'low-energy collision-induced dissociation'
-                        elif int(collision_energy) > 1000:
-                            activation = 'collision-induced dissociation'
-                    elif int(activation_value) == 1:
-                        activation = 'electron transfer dissociation'
-                '''
-
-                scan_dict = {'scan_number': None,
-                             'mz_array': tdf_data.mz_values[spectrum_tof_indices[start:end]],
-                             'intensity_array': spectrum_intensity_values[start:end],
-                             'scan_type': 'MSn spectrum',
-                             'polarity': polarity,
-                             'centroided': centroid,
-                             'retention_time': float(rtinseconds[index - 1] / 60),  # in min
-                             'total_ion_current': sum(spectrum_intensity_values[start:end]),
-                             'ms_level': 2,
-                             'target_mz': average_mzs[index - 1],
-                             'isolation_lower_offset': half_isolation_width,
-                             'isolation_upper_offset': half_isolation_width,
-                             'selected_ion_mz': float(mono_mzs[index - 1]),
-                             'selected_ion_intensity': float(intensities[index - 1]),
-                             'selected_ion_mobility': float(mobilities[index - 1]),
-                             'charge_state': int(charges[index - 1]),
-                             #'activation': activation,
-                             'collision_energy': collision_energy,
-                             'parent_frame': parent_frames[index - 1],
-                             'parent_scan': int(parent_scans[index - 1])}
-
-                # Get base peak information.
-                if spectrum_intensity_values[start:end].size != 0:
-                    base_peak_index = spectrum_intensity_values[start:end].argmax()
-                    scan_dict['base_peak_mz'] = float(tdf_data.mz_values[spectrum_tof_indices[start:end]]
-                                                      [base_peak_index])
-                    scan_dict['base_peak_intensity'] = float(spectrum_intensity_values[base_peak_index])
-
-                # Get high and low spectrum m/z values.
-                if tdf_data.mz_values[spectrum_tof_indices[start:end]].size != 0:
-                    scan_dict['high_mz'] = float(max(tdf_data.mz_values[spectrum_tof_indices[start:end]]))
-                    scan_dict['low_mz'] = float(min(tdf_data.mz_values[spectrum_tof_indices[start:end]]))
-
-                list_of_scan_dicts.append(scan_dict)
-
-    # Close connection to database.
-    con.close()
-
-    ms2_scans_dict = {}
-    # Loop through frames.
-    for key, value in itertools.groupby(list_of_scan_dicts, key_func_frames):
-        if ms1_groupby == 'scan':
-            # Loop through scans.
-            for key2, value2 in itertools.groupby(list(value), key_func_scans):
-                ms2_scans_dict['f' + str(key) + 's' + str(key2)] = list(value2)
-        elif ms1_groupby == 'frame':
-            ms2_scans_dict[key] = list(value)
-
-    return ms2_scans_dict
-
-
-# Extract all scan information including acquisition parameters, m/z, intensity, and mobility arrays/values
-# from dataframes for each scan.
-def parse_lcms_tdf(tdf_data, ms1_frames, infile, centroid, ms2_only, ms1_groupby, ms2_keep_n_most_abundant_peaks):
-    # Get all MS2 scans into dictionary.
-    # keys == parent scan
-    # values == list of scan dicts containing all the MS2 product scans for a given parent scan
-    logging.info(get_timestamp() + ':' + 'Parsing LC-TIMS-MS/MS MS2 spectra.')
-    ms2_scans_dict = parse_lcms_tdf_ms2_scans(tdf_data, infile, centroid, ms1_groupby, ms2_keep_n_most_abundant_peaks)
-
-    # Get all MS1 scans into dictionary.
-    logging.info(get_timestamp() + ':' + 'Parsing LC-TIMS-MS MS1 spectra.')
-    ms1_scans_dict = {}
-    for frame_num in ms1_frames:
-        if ms1_groupby == 'scan':
-            ms1_scans = sorted(list(set(tdf_data[frame_num]['scan_indices'])))
-            for scan_num in ms1_scans:
-                parent_scan = tdf_data[frame_num, scan_num].sort_values(by='mz_values')
+            if frames_dict['MsMsType'] in MSMS_TYPE_CATEGORY['ms1']:
                 if ms2_only == False:
-                    ms1_scan = parse_lcms_tdf_ms1_scan(parent_scan, frame_num, infile, centroid, ms1_groupby)
-                    ms1_scans_dict['f' + str(frame_num) + 's' + str(scan_num)] = ms1_scan
-                elif ms2_only == True:
-                    ms1_scans_dict['f' + str(frame_num) + 's' + str(scan_num)] = None
-        elif ms1_groupby == 'frame':
-            parent_scan = tdf_data[frame_num].sort_values(by='mz_values')
-            if ms2_only == False:
-                ms1_scan = parse_lcms_tdf_ms1_scan(parent_scan, frame_num, infile, centroid, ms1_groupby)
-                ms1_scans_dict[frame_num] = ms1_scan
-            elif ms2_only == True:
-                ms1_scans_dict[frame_num] = None
+                    for scan_num in range(0, int(frames_dict['NumScans']) + 1):
+                        scans = tdf_data.read_scans(int(row['Id']), scan_num, scan_num + 1)
+                        if len(scans) == 1:
+                            index_buf, intensity_array = scans[0]
+                        elif len(scans) != 1:
+                            logging.warning(get_timestamp() + ':' + 'Too Many Scans.')
+                            sys.exit(1)
+                        mz_array = tdf_data.index_to_mz(int(row['Id']), index_buf)
 
-    return ms1_scans_dict, ms2_scans_dict
+                        if mz_array.size != 0 and intensity_array.size != 0:
+                            base_peak_index = np.where(intensity_array == np.max(intensity_array))
+
+                            scan_dict = {'scan_number': int(scan_num),
+                                         'scan_type': 'MS1 spectrum',
+                                         'ms_level': 1,
+                                         'mz_array': mz_array,
+                                         'intensity_array': intensity_array,
+                                         'mobility': tdf_data.scan_num_to_oneoverk0(int(row['Id']), np.array([scan_num]))[0],
+                                         'polarity': frames_dict['Polarity'],
+                                         'centroided': centroid,
+                                         'retention_time': float(frames_dict['Time']),
+                                         'total_ion_current': sum(intensity_array),
+                                         'base_peak_mz': mz_array[base_peak_index][0].astype(float),
+                                         'base_peak_intensity': intensity_array[base_peak_index][0].astype(float),
+                                         'high_mz': float(max(mz_array)),
+                                         'low_mz': float(min(mz_array)),
+                                         'frame': int(row['Id'])}
+                            list_of_parent_scan_dicts.append(scan_dict)
+            elif frames_dict['MsMsType'] in MSMS_TYPE_CATEGORY['ms2']:
+                pasefframemsmsinfo_dicts = [i for i in list_of_pasefframemsmsinfo_dict
+                                           if int(i['Frame']) == int(row['Id'])]
+                for pasefframemsmsinfo_dict in pasefframemsmsinfo_dicts:
+                    precursor_dict = [i for i in list_of_precursors_dict
+                                      if int(i['Id']) == int(pasefframemsmsinfo_dict['Precursor'])][0]
+                    scan_begin = pasefframemsmsinfo_dict['ScanNumBegin']
+                    scan_end = pasefframemsmsinfo_dict['ScanNumEnd']
+                    mz_array, intensity_array = tdf_data.extract_spectrum_for_frame_v2(int(row['Id']),
+                                                                                       scan_begin,
+                                                                                       scan_end,
+                                                                                       encoding)
+                    if mz_array.size != 0 and intensity_array.size != 0:
+                        base_peak_index = np.where(intensity_array == np.max(intensity_array))
+
+                        scan_dict = {'scan_number': None,
+                                     'scan_type': 'MSn spectrum',
+                                     'ms_level': 2,
+                                     'mz_array': mz_array,
+                                     'intensity_array': intensity_array,
+                                     'mobility_array': tdf_data.scan_num_to_oneoverk0(int(row['Id']),
+                                                                                      np.array(list(range(scan_begin,
+                                                                                                          scan_end)))),
+                                     'polarity': frames_dict['Polarity'],
+                                     'centroided': centroid,
+                                     'retention_time': float(frames_dict['Time']),
+                                     'total_ion_current': sum(intensity_array),
+                                     'base_peak_mz': mz_array[base_peak_index][0].astype(float),
+                                     'base_peak_intensity': intensity_array[base_peak_index][0].astype(float),
+                                     'high_mz': float(max(mz_array)),
+                                     'low_mz': float(min(mz_array)),
+                                     'target_mz': pasefframemsmsinfo_dict['IsolationMz'],
+                                     'isolation_lower_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
+                                     'isolation_upper_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
+                                     'selected_ion_mz': pasefframemsmsinfo_dict['IsolationMz'],
+                                     'selected_ion_intensity': precursor_dict['Intensity'],
+                                     'charge_state': precursor_dict['Charge'],
+                                     'collision_energy': pasefframemsmsinfo_dict['CollisionEnergy'],
+                                     'parent_frame': int(precursor_dict['Parent']),
+                                     'parent_scan': int(scan_begin)}
+                        list_of_product_scan_dicts.append(scan_dict)
+        elif ms1_groupby == 'frame':
+            if frames_dict['MsMsType'] in MSMS_TYPE_CATEGORY['ms1']:
+                if ms2_only == False:
+                    mz_array, intensity_array = tdf_data.extract_spectrum_for_frame_v2(int(row['Id']),
+                                                                                       0,
+                                                                                       int(frames_dict['NumScans']),
+                                                                                       encoding)
+                    if mz_array.size != 0 and intensity_array.size != 0:
+                        base_peak_index = np.where(intensity_array == np.max(intensity_array))
+
+                        scan_dict = {'scan_number': None,
+                                     'scan_type': 'MS1 spectrum',
+                                     'ms_level': 1,
+                                     'mz_array': mz_array,
+                                     'intensity_array': intensity_array,
+                                     'mobility_array': tdf_data.scan_num_to_oneoverk0(int(row['Id']),
+                                                                                      np.array(list(range(1, int(frames_dict['NumScans'])+1)))),
+                                     'polarity': frames_dict['Polarity'],
+                                     'centroided': centroid,
+                                     'retention_time': float(frames_dict['Time']),
+                                     'total_ion_current': sum(intensity_array),
+                                     'base_peak_mz': mz_array[base_peak_index][0].astype(float),
+                                     'base_peak_intensity': intensity_array[base_peak_index][0].astype(float),
+                                     'high_mz': float(max(mz_array)),
+                                     'low_mz': float(min(mz_array)),
+                                     'frame': int(row['Id'])}
+                        list_of_parent_scan_dicts.append(scan_dict)
+            elif frames_dict['MsMsType'] in MSMS_TYPE_CATEGORY['ms2']:
+                pasefframemsmsinfo_dicts = [i for i in list_of_pasefframemsmsinfo_dict
+                                            if int(i['Frame']) == int(row['Id'])]
+                for pasefframemsmsinfo_dict in pasefframemsmsinfo_dicts:
+                    precursor_dict = [i for i in list_of_precursors_dict
+                                      if int(i['Id']) == int(pasefframemsmsinfo_dict['Precursor'])][0]
+                    scan_begin = pasefframemsmsinfo_dict['ScanNumBegin']
+                    scan_end = pasefframemsmsinfo_dict['ScanNumEnd']
+                    mz_array, intensity_array = tdf_data.extract_spectrum_for_frame_v2(int(row['Id']),
+                                                                                       scan_begin,
+                                                                                       scan_end,
+                                                                                       encoding)
+                    if mz_array.size != 0 and intensity_array.size != 0:
+                        base_peak_index = np.where(intensity_array == np.max(intensity_array))
+
+                        scan_dict = {'scan_number': None,
+                                     'scan_type': 'MSn spectrum',
+                                     'ms_level': 2,
+                                     'mz_array': mz_array,
+                                     'intensity_array': intensity_array,
+                                     'mobility_array': tdf_data.scan_num_to_oneoverk0(int(row['Id']),
+                                                                                      np.array(list(range(scan_begin,
+                                                                                                          scan_end)))),
+                                     'polarity': frames_dict['Polarity'],
+                                     'centroided': centroid,
+                                     'retention_time': float(frames_dict['Time']),
+                                     'total_ion_current': sum(intensity_array),
+                                     'base_peak_mz': mz_array[base_peak_index][0].astype(float),
+                                     'base_peak_intensity': intensity_array[base_peak_index][0].astype(float),
+                                     'high_mz': float(max(mz_array)),
+                                     'low_mz': float(min(mz_array)),
+                                     'target_mz': pasefframemsmsinfo_dict['IsolationMz'],
+                                     'isolation_lower_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
+                                     'isolation_upper_offset': float(pasefframemsmsinfo_dict['IsolationWidth']) / 2,
+                                     'selected_ion_mz': pasefframemsmsinfo_dict['IsolationMz'],
+                                     'selected_ion_intensity': precursor_dict['Intensity'],
+                                     'charge_state': precursor_dict['Charge'],
+                                     'collision_energy': pasefframemsmsinfo_dict['CollisionEnergy'],
+                                     'parent_frame': int(precursor_dict['Parent'])}
+                        list_of_product_scan_dicts.append(scan_dict)
+    return list_of_parent_scan_dicts, list_of_product_scan_dicts
 
 
 if __name__ == '__main__':

--- a/timsconvert/parse_maldi.py
+++ b/timsconvert/parse_maldi.py
@@ -25,7 +25,7 @@ def parse_maldi_tsf(tsf_data, centroid):
         mz_array = tsf_data.index_to_mz(int(row['Frame']), index_buf)
 
         if mz_array.size != 0 and intensity_array.size != 0:
-            base_peak_index = np.where(intensity_array == np.max(intensity_array))
+            base_peak_index = np.where(intensity_array == np.max(intensity_array))[0][0]
 
             if tsf_data.meta_data['MaldiApplicationType'] == 'SingleSpectra':
                 coords = row['SpotName']
@@ -68,6 +68,10 @@ def parse_maldi_tsf(tsf_data, centroid):
                 scan_dict['collision_energy'] = framemsmsinfo_dict['CollisionEnergy']
                 # no parent frame or scan
 
+            if len(scan_dict['mz_array']) != len(scan_dict['intensity_array']):
+                print(scan_dict)
+                print(len(scan_dict['mz_array']))
+                print(len(scan_dict['intensity_array']))
             list_of_scan_dicts.append(scan_dict)
     return list_of_scan_dicts
 
@@ -91,12 +95,12 @@ def parse_maldi_tdf(tdf_data, groupby, encoding, centroid):
                 if len(scans) == 1:
                     index_buf, intensity_array = scans[0]
                 elif len(scans) != 1:
-                    print('Too Many Scans.')
+                    logging.warning(get_timestamp() + ':' + 'Too Many Scans.')
                     sys.exit(1)
                 mz_array = tdf_data.index_to_mz(int(row['Frame']), index_buf)
 
                 if mz_array.size != 0 and intensity_array.size != 0:
-                    base_peak_index = np.where(intensity_array == np.max(intensity_array))
+                    base_peak_index = np.where(intensity_array == np.max(intensity_array))[0][0]
 
                     if tdf_data.meta_data['MaldiApplicationType'] == 'SingleSpectra':
                         coords = row['SpotName']
@@ -149,7 +153,7 @@ def parse_maldi_tdf(tdf_data, groupby, encoding, centroid):
                                                                                           encoding)
 
             if mz_array.size != 0 and intensity_array.size != 0:
-                base_peak_index = np.where(intensity_array == np.max(intensity_array))
+                base_peak_index = np.where(intensity_array == np.max(intensity_array))[0][0]
 
                 if tdf_data.meta_data['MaldiApplicationType'] == 'SingleSpectra':
                     coords = row['SpotName']

--- a/timsconvert/write_imzml.py
+++ b/timsconvert/write_imzml.py
@@ -28,6 +28,10 @@ def write_maldi_ims_imzml(data, outdir, outfile, groupby='frame', encoding=0, im
     logging.info(get_timestamp() + ':' + 'Writing to .imzML file ' + os.path.join(outdir, outfile) + '...')
     with writer as imzml_file:
         for scan_dict in list_of_scan_dicts:
+            if len(scan_dict['mz_array']) != len(scan_dict['intensity_array']):
+                print(scan_dict)
+                print(len(scan_dict['mz_array']))
+                print(len(scan_dict['intensity_array']))
             imzml_file.addSpectrum(scan_dict['mz_array'],
                                    scan_dict['intensity_array'],
                                    scan_dict['coord'])

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -202,7 +202,6 @@ def write_lcms_mzml(data, infile, outdir, outfile, centroid, ms2_only, ms1_group
                     # Write MS1 parent scans.
                     for parent in parent_scans:
                         products = [i for i in product_scans if i['parent_frame'] == parent['frame']]
-                        print(products)
                         # Set params for scan.
                         if ms2_only == False:
                             scan_count += 1

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -90,7 +90,6 @@ def write_lcms_ms2_spectrum(writer, parent_scan, encoding, product_scan):
     # Build precursor information dict.
     precursor_info = {'mz': product_scan['selected_ion_mz'],
                       'intensity': product_scan['selected_ion_intensity'],
-                      'charge': product_scan['charge_state'],
                       #'activation': [product_scan['activation'],
                       #               {'collision energy': product_scan['collision_energy']}],
                       'activation': [{'collision energy': product_scan['collision_energy']}],
@@ -98,6 +97,8 @@ def write_lcms_ms2_spectrum(writer, parent_scan, encoding, product_scan):
                                                 'upper': product_scan['isolation_upper_offset'],
                                                 'lower': product_scan['isolation_lower_offset']},
                       'params': {'product ion mobility': product_scan['selected_ion_mobility']}}
+    if not np.isnan(product_scan['charge_state']):
+        precursor_info['charge'] = product_scan['charge_state']
 
     if parent_scan != None:
         precursor_info['spectrum_reference'] = 'scan=' + str(parent_scan['scan_number'])

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -173,7 +173,10 @@ def write_lcms_mzml(data, infile, outdir, outfile, centroid, ms2_only, ms1_group
         if data.meta_data['SchemaType'] == 'TDF':
             parent_scans, product_scans = parse_lcms_tdf(data, ms1_groupby, centroid, encoding, ms2_only)
         # later add code for elif baf -> use baf2sql
-        num_of_spectra = len(parent_scans) + len(product_scans)
+        if ms2_only == False:
+            num_of_spectra = len(parent_scans) + len(product_scans)
+        elif ms2_only == True:
+            num_of_spectra = len(product_scans)
 
         logging.info(get_timestamp() + ':' + 'Writing to .mzML file ' + os.path.join(outdir, outfile) + '...')
         # Writing data to spectrum

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -182,37 +182,49 @@ def write_lcms_mzml(data, infile, outdir, outfile, centroid, ms2_only, ms1_group
             with writer.spectrum_list(count=num_of_spectra):
                 if ms1_groupby == 'scan':
                     # Write MS1 parent scans.
-                    for parent in parent_scans:
-                        products = [i for i in product_scans
-                                    if i['parent_frame'] == parent['frame'] and
-                                    i['parent_scan'] == parent['scan_number']]
-                        # Set params for scan.
-                        if ms2_only == False:
+                    if ms2_only == False:
+                        for parent in parent_scans:
+                            products = [i for i in product_scans
+                                        if i['parent_frame'] == parent['frame'] and
+                                        i['parent_scan'] == parent['scan_number']]
+                            # Set params for scan.
                             scan_count += 1
                             parent['scan_number'] = scan_count
                             logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
                             write_lcms_ms1_spectrum(writer, parent, encoding, ms1_groupby)
-                        # Write MS2 product scans.
-                        for product in products:
+                            # Write MS2 product scans.
+                            for product in products:
+                                scan_count += 1
+                                product['scan_number'] = scan_count
+                                logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
+                                write_lcms_ms2_spectrum(writer, parent, encoding, product)
+                    elif ms2_only == True or parent_scans == []:
+                        for product in product_scans:
                             scan_count += 1
                             product['scan_number'] = scan_count
                             logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
-                            write_lcms_ms2_spectrum(writer, parent, encoding, product)
+                            write_lcms_ms2_spectrum(writer, None, encoding, product)
                 elif ms1_groupby == 'frame':
                     # Write MS1 parent scans.
-                    for parent in parent_scans:
-                        products = [i for i in product_scans if i['parent_frame'] == parent['frame']]
-                        # Set params for scan.
-                        if ms2_only == False:
+                    if ms2_only == False:
+                        for parent in parent_scans:
+                            products = [i for i in product_scans if i['parent_frame'] == parent['frame']]
+                            # Set params for scan.
                             scan_count += 1
                             parent['scan_number'] = scan_count
                             logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
                             write_lcms_ms1_spectrum(writer, parent, encoding, ms1_groupby)
-                        for product in products:
+                            for product in products:
+                                scan_count += 1
+                                product['scan_number'] = scan_count
+                                logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
+                                write_lcms_ms2_spectrum(writer, parent, encoding, product)
+                    if ms2_only == True:
+                        for product in product_scans:
                             scan_count += 1
                             product['scan_number'] = scan_count
                             logging.info(get_timestamp() + ':' + 'Writing Scan ' + str(scan_count))
-                            write_lcms_ms2_spectrum(writer, parent, encoding, product)
+                            write_lcms_ms2_spectrum(writer, None, encoding, product)
 
 
 def write_maldi_dd_mzml(data, infile, outdir, outfile, ms2_only, groupby, centroid=True, encoding=0,


### PR DESCRIPTION
Switch LC-TIMS-MS(/MS) workflow over to using Bruker TDF-SDK instead of AlphaTims. This may slightly change the resulting data as AlphaTims uses different import/reading algorithms than TDF-SDK in certain instances.