### PR TITLE
Tdfsdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.20
 pandas
 lxml
-alphatims
 psims
 pyimzML
 xmltodict
+hdf5plugins

--- a/timsconvert/__init__.py
+++ b/timsconvert/__init__.py
@@ -13,8 +13,6 @@ import logging
 import numpy as np
 import pandas as pd
 
-import alphatims.bruker
-import alphatims.utils
 from psims.mzml import MzMLWriter
 from pyimzml.ImzMLWriter import ImzMLWriter
 

--- a/timsconvert/arguments.py
+++ b/timsconvert/arguments.py
@@ -40,11 +40,6 @@ def get_args():
     parser.add_argument('--imzml_mode', help='Whether .imzML files should be written in "processed" or "continuous" '
                                              'mode. Defaults to "processed".', default='processed', type=str)
 
-    # Advanced MS2 Centroiding Arguments: taken from alphatims.bruker.centroid_spectrum()
-    parser.add_argument('--ms2_keep_n_most_abundant_peaks', help='Keep N most abundant peaks in MS2 spectra. If -1, all'
-                                                                 'peaks are kept. Defaults to -1.', default=-1,
-                        type=int)
-
     # System Arguments
     parser.add_argument('--verbose', help='Boolean flag to detemrine whether to print logging output.',
                         action='store_true')

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -305,39 +305,41 @@ class tdf_data(object):
 
         return result
 
-    def extract_centroided_spectrum_for_frame(self, frame_id, scan_begin, scan_end):
-        result = None
+    # Only define extract_centroided_spectrum_for_frame and extract_profile_spectrum_for_frame if using SDK 2.8.7.1.
+    if SDK_VERSION == 'sdk2871':
+        def extract_centroided_spectrum_for_frame(self, frame_id, scan_begin, scan_end):
+            result = None
 
-        @MSMS_SPECTRUM_FUNCTOR
-        def callback_for_dll(precursor_id, num_peaks, mz_values, area_values):
-            nonlocal result
-            result = (mz_values[0:num_peaks], area_values[0:num_peaks])
+            @MSMS_SPECTRUM_FUNCTOR
+            def callback_for_dll(precursor_id, num_peaks, mz_values, area_values):
+                nonlocal result
+                result = (mz_values[0:num_peaks], area_values[0:num_peaks])
 
-        rc = self.dll.tims_extract_centroided_spectrum_for_frame(self.handle,
-                                                                 frame_id,
-                                                                 scan_begin,
-                                                                 scan_end,
-                                                                 callback_for_dll,
-                                                                 None)
+            rc = self.dll.tims_extract_centroided_spectrum_for_frame(self.handle,
+                                                                     frame_id,
+                                                                     scan_begin,
+                                                                     scan_end,
+                                                                     callback_for_dll,
+                                                                     None)
 
-        return result
+            return result
 
-    def extract_profile_spectrum_for_frame(self, frame_id, scan_begin, scan_end):
-        result = None
+        def extract_profile_spectrum_for_frame(self, frame_id, scan_begin, scan_end):
+            result = None
 
-        @MSMS_PROFILE_SPECTRUM_FUNCTOR
-        def callback_for_dll(precursor_id, num_points, intensity_values):
-            nonlocal result
-            result = intensity_values[0:num_points]
+            @MSMS_PROFILE_SPECTRUM_FUNCTOR
+            def callback_for_dll(precursor_id, num_points, intensity_values):
+                nonlocal result
+                result = intensity_values[0:num_points]
 
-        rc = self.dll.tims_extract_profile_for_frame(self.handle,
-                                                     frame_id,
-                                                     scan_begin,
-                                                     scan_end,
-                                                     callback_for_dll,
-                                                     None)
+            rc = self.dll.tims_extract_profile_for_frame(self.handle,
+                                                         frame_id,
+                                                         scan_begin,
+                                                         scan_end,
+                                                         callback_for_dll,
+                                                         None)
 
-        return result
+            return result
 
     # In house code for getting spectrum for a frame.
     def extract_spectrum_for_frame_v2(self, frame_id, begin_scan, end_scan, encoding, tol=0.01):

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -267,21 +267,23 @@ class tdf_data(object):
 
         return result
 
-    def read_pasef_profile_msms(self, precursor_list):
-        precursors_for_dll = np.array(precursor_list, dtype=np.int64)
+    # Only define if using SDK 2.8.7.1 or SDK 2.7.0.
+    if SDK_VERSION == 'sdk2871' or SDK_VERSION == 'sdk270':
+        def read_pasef_profile_msms(self, precursor_list):
+            precursors_for_dll = np.array(precursor_list, dtype=np.int64)
 
-        result = {}
+            result = {}
 
-        @MSMS_PROFILE_SPECTRUM_FUNCTOR
-        def callback_for_dll(precursor_id, num_points, intensity_values):
-            result[precursor_id] = intensity_values[0:num_points]
+            @MSMS_PROFILE_SPECTRUM_FUNCTOR
+            def callback_for_dll(precursor_id, num_points, intensity_values):
+                result[precursor_id] = intensity_values[0:num_points]
 
-        rc = self.dll.tims_read_pasef_profile_msms(self.handle,
-                                                   precursors_for_dll.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
-                                                   len(precursor_list),
-                                                   callback_for_dll)
+            rc = self.dll.tims_read_pasef_profile_msms(self.handle,
+                                                       precursors_for_dll.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
+                                                       len(precursor_list),
+                                                       callback_for_dll)
 
-        return result
+            return result
 
     def read_pasef_centroid_msms_for_frame(self, frame_id):
         result = {}
@@ -294,16 +296,18 @@ class tdf_data(object):
 
         return result
 
-    def read_pasef_profile_msms_for_frame(self, frame_id):
-        result = {}
+    # Only define if using SDK 2.8.7.1 or SDK 2.7.0.
+    if SDK_VERSION == 'sdk2871' or SDK_VERSION == 'sdk270':
+        def read_pasef_profile_msms_for_frame(self, frame_id):
+            result = {}
 
-        @MSMS_PROFILE_SPECTRUM_FUNCTOR
-        def callback_for_dll(precursor_id, num_points, intensity_values):
-            result[precursor_id] = intensity_values[0:num_points]
+            @MSMS_PROFILE_SPECTRUM_FUNCTOR
+            def callback_for_dll(precursor_id, num_points, intensity_values):
+                result[precursor_id] = intensity_values[0:num_points]
 
-        rc = self.dll.tims_read_pasef_profile_msms_for_frame(self.handle, frame_id, callback_for_dll)
+            rc = self.dll.tims_read_pasef_profile_msms_for_frame(self.handle, frame_id, callback_for_dll)
 
-        return result
+            return result
 
     # Only define extract_centroided_spectrum_for_frame and extract_profile_spectrum_for_frame if using SDK 2.8.7.1.
     if SDK_VERSION == 'sdk2871':

--- a/timsconvert/constants.py
+++ b/timsconvert/constants.py
@@ -67,7 +67,7 @@ if platform.system() == 'Windows':
         BRUKER_DLL_FILE_NAME = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                                             os.path.join('lib', SDK_VERSION, 'win32', 'timsdata.dll'))
 elif platform.system() == 'Linux':
-    SDK_VERSION = 'sdk270'
+    SDK_VERSION = 'sdk244'
     BRUKER_DLL_FILE_NAME = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                                         os.path.join('lib', SDK_VERSION, 'linux64', 'timsdata.so'))
 else:

--- a/timsconvert/constants.py
+++ b/timsconvert/constants.py
@@ -59,14 +59,17 @@ MSMS_TYPE_CATEGORY = {'ms1': [0],
 
 if platform.system() == 'Windows':
     if platform.architecture()[0] == '64bit':
+        SDK_VERSION = 'sdk2871'
         BRUKER_DLL_FILE_NAME = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                                            os.path.join('lib', 'sdk2871', 'win64', 'timsdata.dll'))
+                                            os.path.join('lib', SDK_VERSION, 'win64', 'timsdata.dll'))
     elif platform.architecture()[0] == '32bit':
+        SDK_VERSION = 'sdk2871'
         BRUKER_DLL_FILE_NAME = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                                            os.path.join('lib', 'sdk2871', 'win32', 'timsdata.dll'))
+                                            os.path.join('lib', SDK_VERSION, 'win32', 'timsdata.dll'))
 elif platform.system() == 'Linux':
+    SDK_VERSION = 'sdk270'
     BRUKER_DLL_FILE_NAME = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                                        os.path.join('lib', 'sdk2871', 'linux64', 'timsdata.so'))
+                                        os.path.join('lib', SDK_VERSION, 'linux64', 'timsdata.so'))
 else:
     logging.info(get_timestamp() + ':' + 'Bruker API not found...')
     logging.info(get_timestamp() + ':' + 'Exiting...')

--- a/timsconvert/data_input.py
+++ b/timsconvert/data_input.py
@@ -1,4 +1,3 @@
-import alphatims.bruker
 import os
 import logging
 import sqlite3

--- a/timsconvert/init_bruker_dll.py
+++ b/timsconvert/init_bruker_dll.py
@@ -84,20 +84,22 @@ def init_bruker_dll(bruker_dll_file_name: str=BRUKER_DLL_FILE_NAME):
     bruker_dll.tims_read_pasef_profile_msms_for_frame.restype = ctypes.c_uint32
 
     # Extract spectra from frames
-    bruker_dll.tims_extract_centroided_spectrum_for_frame.argtypes = [ctypes.c_uint64,
-                                                                      ctypes.c_int64,
-                                                                      ctypes.c_uint32,
-                                                                      ctypes.c_uint32,
-                                                                      MSMS_SPECTRUM_FUNCTOR,
-                                                                      ctypes.c_void_p]
-    bruker_dll.tims_extract_centroided_spectrum_for_frame.restype = ctypes.c_uint32
-    bruker_dll.tims_extract_profile_for_frame.argtypes = [ctypes.c_uint64,
-                                                          ctypes.c_int64,
-                                                          ctypes.c_uint32,
-                                                          ctypes.c_uint32,
-                                                          MSMS_PROFILE_SPECTRUM_FUNCTOR,
-                                                          ctypes.c_void_p]
-    bruker_dll.tims_extract_profile_for_frame.restype = ctypes.c_uint32
+    # Only available in SDK version 2.8.7.1
+    if SDK_VERSION == 'sdk2871':
+        bruker_dll.tims_extract_centroided_spectrum_for_frame.argtypes = [ctypes.c_uint64,
+                                                                          ctypes.c_int64,
+                                                                          ctypes.c_uint32,
+                                                                          ctypes.c_uint32,
+                                                                          MSMS_SPECTRUM_FUNCTOR,
+                                                                          ctypes.c_void_p]
+        bruker_dll.tims_extract_centroided_spectrum_for_frame.restype = ctypes.c_uint32
+        bruker_dll.tims_extract_profile_for_frame.argtypes = [ctypes.c_uint64,
+                                                              ctypes.c_int64,
+                                                              ctypes.c_uint32,
+                                                              ctypes.c_uint32,
+                                                              MSMS_PROFILE_SPECTRUM_FUNCTOR,
+                                                              ctypes.c_void_p]
+        bruker_dll.tims_extract_profile_for_frame.restype = ctypes.c_uint32
 
     # Get m/z values from indices
     convfunc_argtypes = [ctypes.c_uint64,

--- a/timsconvert/init_bruker_dll.py
+++ b/timsconvert/init_bruker_dll.py
@@ -7,34 +7,36 @@ def init_bruker_dll(bruker_dll_file_name: str=BRUKER_DLL_FILE_NAME):
     bruker_dll = ctypes.cdll.LoadLibrary(os.path.realpath(bruker_dll_file_name))
 
     # Functions for .tsf files
-    # .tsf Open
-    bruker_dll.tsf_open.argtypes = [ctypes.c_char_p, ctypes.c_uint32]
-    bruker_dll.tsf_open.restype = ctypes.c_uint64
+    # Only load .tsf functions if on Windows; newer Linux .so library errors our due to Boost C++ lib in source code.
+    if SDK_VERSION == 'sdk2871' or SDK_VERSION == 'sdk270':
+        # .tsf Open
+        bruker_dll.tsf_open.argtypes = [ctypes.c_char_p, ctypes.c_uint32]
+        bruker_dll.tsf_open.restype = ctypes.c_uint64
 
-    # .tsf Close
-    bruker_dll.tsf_close.argtypes = [ctypes.c_uint64]
-    bruker_dll.tsf_close.restype = None
+        # .tsf Close
+        bruker_dll.tsf_close.argtypes = [ctypes.c_uint64]
+        bruker_dll.tsf_close.restype = None
 
-    # Read in profile or line spectra
-    bruker_dll.tsf_read_line_spectrum.argtypes = [ctypes.c_uint64,
-                                                  ctypes.c_int64,
-                                                  ctypes.POINTER(ctypes.c_double),
-                                                  ctypes.POINTER(ctypes.c_float),
-                                                  ctypes.c_uint32]
-    bruker_dll.tsf_read_line_spectrum.restype = ctypes.c_uint32
-    bruker_dll.tsf_read_profile_spectrum.argtypes = [ctypes.c_uint64,
-                                                     ctypes.c_int64,
-                                                     ctypes.POINTER(ctypes.c_uint32),
-                                                     ctypes.c_uint32]
-    bruker_dll.tsf_read_profile_spectrum.restype = ctypes.c_uint32
+        # Read in profile or line spectra
+        bruker_dll.tsf_read_line_spectrum.argtypes = [ctypes.c_uint64,
+                                                      ctypes.c_int64,
+                                                      ctypes.POINTER(ctypes.c_double),
+                                                      ctypes.POINTER(ctypes.c_float),
+                                                      ctypes.c_uint32]
+        bruker_dll.tsf_read_line_spectrum.restype = ctypes.c_uint32
+        bruker_dll.tsf_read_profile_spectrum.argtypes = [ctypes.c_uint64,
+                                                         ctypes.c_int64,
+                                                         ctypes.POINTER(ctypes.c_uint32),
+                                                         ctypes.c_uint32]
+        bruker_dll.tsf_read_profile_spectrum.restype = ctypes.c_uint32
 
-    # Get m/z values from indices.
-    bruker_dll.tsf_index_to_mz.argtypes = [ctypes.c_uint64,
-                                           ctypes.c_int64,
-                                           ctypes.POINTER(ctypes.c_double),
-                                           ctypes.POINTER(ctypes.c_double),
-                                           ctypes.c_uint32]
-    bruker_dll.tsf_index_to_mz.restype = ctypes.c_uint32
+        # Get m/z values from indices.
+        bruker_dll.tsf_index_to_mz.argtypes = [ctypes.c_uint64,
+                                               ctypes.c_int64,
+                                               ctypes.POINTER(ctypes.c_double),
+                                               ctypes.POINTER(ctypes.c_double),
+                                               ctypes.c_uint32]
+        bruker_dll.tsf_index_to_mz.restype = ctypes.c_uint32
 
     # Functions for .tdf files
     # .tdf Open
@@ -73,15 +75,17 @@ def init_bruker_dll(bruker_dll_file_name: str=BRUKER_DLL_FILE_NAME):
                                                      ctypes.c_int64,
                                                      ctypes.c_uint32,
                                                      ctypes.POINTER(ctypes.c_int32))
-    bruker_dll.tims_read_pasef_profile_msms.argtypes = [ctypes.c_uint64,
-                                                        ctypes.POINTER(ctypes.c_int64),
-                                                        ctypes.c_uint32,
-                                                        MSMS_PROFILE_SPECTRUM_FUNCTOR]
-    bruker_dll.tims_read_pasef_profile_msms.restype = ctypes.c_uint32
-    bruker_dll.tims_read_pasef_profile_msms_for_frame.argtypes = [ctypes.c_uint64,
-                                                                  ctypes.c_int64,
-                                                                  MSMS_PROFILE_SPECTRUM_FUNCTOR]
-    bruker_dll.tims_read_pasef_profile_msms_for_frame.restype = ctypes.c_uint32
+    # Only available in SDK version 2.8.7.1 or 2.7.0.
+    if SDK_VERSION == 'sdk2871' or SDK_VERSION == 'sdk270':
+        bruker_dll.tims_read_pasef_profile_msms.argtypes = [ctypes.c_uint64,
+                                                            ctypes.POINTER(ctypes.c_int64),
+                                                            ctypes.c_uint32,
+                                                            MSMS_PROFILE_SPECTRUM_FUNCTOR]
+        bruker_dll.tims_read_pasef_profile_msms.restype = ctypes.c_uint32
+        bruker_dll.tims_read_pasef_profile_msms_for_frame.argtypes = [ctypes.c_uint64,
+                                                                      ctypes.c_int64,
+                                                                      MSMS_PROFILE_SPECTRUM_FUNCTOR]
+        bruker_dll.tims_read_pasef_profile_msms_for_frame.restype = ctypes.c_uint32
 
     # Extract spectra from frames
     # Only available in SDK version 2.8.7.1
@@ -115,10 +119,12 @@ def init_bruker_dll(bruker_dll_file_name: str=BRUKER_DLL_FILE_NAME):
     bruker_dll.tims_scannum_to_oneoverk0.restype = ctypes.c_uint32
 
     # Convert 1/k0 to CCS
-    bruker_dll.tims_oneoverk0_to_ccs_for_mz.argtypes = [ctypes.c_double,
-                                                        ctypes.c_int32,
-                                                        ctypes.c_double]
-    bruker_dll.tims_oneoverk0_to_ccs_for_mz.restype = ctypes.c_double
+    # Only available in SDK version 2.8.7.1 or 2.7.0
+    if SDK_VERSION == 'sdk2871' or SDK_VERSION == 'sdk270':
+        bruker_dll.tims_oneoverk0_to_ccs_for_mz.argtypes = [ctypes.c_double,
+                                                            ctypes.c_int32,
+                                                            ctypes.c_double]
+        bruker_dll.tims_oneoverk0_to_ccs_for_mz.restype = ctypes.c_double
 
     return bruker_dll
 


### PR DESCRIPTION
TDF SDK versions 2.7.0 and above include functions to handle .tsf data but Linux API causes error `boost::interprocess_exception -> boost::interprocess:;intermodule_singleton initialization failed`. Therefore, usage on Linux reverts to SDK version 2.4.4 but loses functionality to handle .tsf data among newer quality of life functions found in the library.