### PR TITLE
Profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /timsconvert.egg-info
 /dist
 /db
+/test/massive.ucsd.edu

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ TIMSCONVERT Optional Parameters
                           Precursor ion mobility information is still exported. Recommended when exporting in profile 
                           mode due to file size.
 --encoding                Choose encoding for binary arrays. 32-bit ("32") or 64-bit ("64"). Defaults to 64-bit.
+--barebones_metadata      Only use basic mzML metadata. Use if downstream data analysis tools throw errors with 
+                          descriptive CV terms.
+--profile_bins            Number of bins used to bin data when converting in profile mode. A value of 0 indicates no 
+                          binning is performed. Default s to 0
 --maldi_output_file       For MALDI dried droplet data, whether individual scans should be placed in
                           individual files ("individual") or all into a single file ("combined").
                           Defaults to combined.

--- a/timsconvert/arguments.py
+++ b/timsconvert/arguments.py
@@ -20,7 +20,6 @@ def arg_descriptions():
                                         'exported data. Precursor ion mobility information is still exported.',
                     'encoding': 'Choose encoding for binary arrays: 32-bit ("32") or 64-bit ("64"). Defaults to '
                                 '64-bit.',
-                    'barebones_metadata'
                     'profile_bins': 'Number of bins used to bin data when converting in profile mode. A value of 0'
                                     'indicates no binning is performed. Defaults to 0.',
                     'barebones_metadata': 'Only use basic mzML metadata. Use if downstream data analysis tools throw '
@@ -64,7 +63,7 @@ def get_args(server=False):
     optional = parser.add_argument_group('Optional Parameters')
     optional.add_argument('--outdir', help=desc['outdir'], default='', type=str)
     optional.add_argument('--outfile', help=desc['outfile'], default='', type=str)
-    optional.add_argument('--mode', help=desc['mode'], default='centroid', type=str, choices=['raw', 'centroid'])
+    optional.add_argument('--mode', help=desc['mode'], default='centroid', type=str, choices=['raw', 'centroid', 'profile'])
     optional.add_argument('--compression', help=desc['compression'], default='zlib', type=str, choices=['zlib', 'none'])
 
     # TIMSCONVERT Arguments
@@ -73,7 +72,7 @@ def get_args(server=False):
     timsconvert_args.add_argument('--exclude_mobility', help=desc['exclude_mobility'], action='store_true')
     timsconvert_args.add_argument('--encoding', help=desc['encoding'], default=64, type=int, choices=[32, 64])
     timsconvert_args.add_argument('--barebones_metadata', help=desc['barebones_metadata'], action='store_true')
-    #timsconvert_args.add_argument('--profile_bins', help=desc['profile_bins'], default=0, type=int)
+    timsconvert_args.add_argument('--profile_bins', help=desc['profile_bins'], default=0, type=int)
     timsconvert_args.add_argument('--maldi_output_file', help=desc['maldi_output_file'], default='combined', type=str,
                                   choices=['combined', 'individual', 'sample'])
     timsconvert_args.add_argument('--maldi_plate_map', help=desc['maldi_plate_map'], default='', type=str)

--- a/timsconvert/arguments.py
+++ b/timsconvert/arguments.py
@@ -20,7 +20,7 @@ def arg_descriptions():
                                         'exported data. Precursor ion mobility information is still exported.',
                     'encoding': 'Choose encoding for binary arrays: 32-bit ("32") or 64-bit ("64"). Defaults to '
                                 '64-bit.',
-                    'profile_bins': 'Number of bins used to bin data when converting in profile mode. A value of 0'
+                    'profile_bins': 'Number of bins used to bin data when converting in profile mode. A value of 0 '
                                     'indicates no binning is performed. Defaults to 0.',
                     'barebones_metadata': 'Only use basic mzML metadata. Use if downstream data analysis tools throw '
                                           'errors with descriptive CV terms.',

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -457,10 +457,9 @@ class tdf_data(object):
                                                          callback_for_dll,
                                                          None)
 
-            print(rc)
-            print(result)
+            index_buf = np.arange(0, len(result), dtype=np.float64)
 
-            return result
+            return (index_buf, result)
 
     # In house code for getting spectrum for a frame.
     def extract_spectrum_for_frame_v2(self, frame_id, begin_scan, end_scan, encoding, tol=0.01):

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -457,6 +457,9 @@ class tdf_data(object):
                                                          callback_for_dll,
                                                          None)
 
+            print(rc)
+            print(result)
+
             return result
 
     # In house code for getting spectrum for a frame.

--- a/timsconvert/classes.py
+++ b/timsconvert/classes.py
@@ -217,7 +217,6 @@ class tsf_data(object):
         return (index_buf[0:required_len], intensity_buf[0:required_len])
 
     # modified from Bruker tsfdata.py
-    # currently unsure of how to get m/z values/indices
     def read_profile_spectrum(self, frame_id):
         while True:
             cnt = int(self.profile_buffer_size)
@@ -235,7 +234,9 @@ class tsf_data(object):
             else:
                 break
 
-        return intensity_buf[0:required_len]
+        index_buf = np.arange(0, intensity_buf.size, dtype=np.float64)
+
+        return (index_buf[0:required_len], intensity_buf[0:required_len])
 
     # Gets global metadata table as a dictionary.
     def get_global_metadata(self):

--- a/timsconvert/parse_lcms.py
+++ b/timsconvert/parse_lcms.py
@@ -21,8 +21,8 @@ def extract_lcms_baf_spectrum_arrays(baf_data, frame_dict, mode, profile_bins, e
         intensity_array = np.array(baf_data.read_array_double(frame_dict['ProfileIntensityId']),
                                    dtype=encoding_dtype)
         if profile_bins != 0:
-            mz_acq_range_lower = float(frame_dict['MzAcqRangeLower'])
-            mz_acq_range_upper = float(frame_dict['MzAcqRangeUpper'])
+            mz_acq_range_lower = float(mz_array[0])
+            mz_acq_range_upper = float(mz_array[-1])
             bins = np.linspace(mz_acq_range_lower, mz_acq_range_upper, profile_bins, dtype=encoding_dtype)
             unique_indices, inverse_indices = np.unique(np.digitize(mz_array, bins), return_inverse=True)
             bin_counts = np.bincount(inverse_indices)

--- a/timsconvert/parse_lcms.py
+++ b/timsconvert/parse_lcms.py
@@ -53,14 +53,13 @@ def extract_lcms_tdf_spectrum_arrays(tdf_data, mode, multiscan, frame, scan_begi
             mz_array, intensity_array = tdf_data.extract_spectrum_for_frame_v2(frame, scan_begin, scan_end, encoding)
             return mz_array, intensity_array
     elif mode == 'profile':
-        intensity_array = np.array(tdf_data.extract_profile_spectrum_for_frame(frame, scan_begin, scan_end),
-                                   dtype=encoding_dtype)
-        mz_acq_range_lower = float(tdf_data.meta_data['MzAcqRangeLower'])
-        mz_acq_range_upper = float(tdf_data.meta_data['MzAcqRangeUpper'])
-        mz_array = np.linspace(mz_acq_range_lower, mz_acq_range_upper, len(intensity_array), dtype=encoding_dtype)
+        index_buf, intensity_array = tdf_data.extract_profile_spectrum_for_frame(frame, scan_begin, scan_end)
+        intensity_array = np.array(intensity_array, dtype=encoding_dtype)
+        mz_array = tdf_data.index_to_mz(frame, index_buf)
         if profile_bins != 0:
-            bin_size = (mz_acq_range_upper - mz_acq_range_lower) / profile_bins
-            bins = np.arange(mz_acq_range_lower, mz_acq_range_upper, bin_size, dtype=encoding_dtype)
+            mz_acq_range_lower = float(mz_array[0])
+            mz_acq_range_upper = float(mz_array[-1])
+            bins = np.linspace(mz_acq_range_lower, mz_acq_range_upper, profile_bins, dtype=encoding_dtype)
             unique_indices, inverse_indices = np.unique(np.digitize(mz_array, bins), return_inverse=True)
             bin_counts = np.bincount(inverse_indices)
             np.place(bin_counts, bin_counts < 1, [1])

--- a/timsconvert/parse_maldi.py
+++ b/timsconvert/parse_maldi.py
@@ -27,7 +27,8 @@ def extract_maldi_tsf_spectrum_arrays(tsf_data, mode, frame, profile_bins, encod
         mz_array = tsf_data.index_to_mz(frame, index_buf)
         return mz_array, intensity_array
     elif mode == 'profile':
-        index_buf, intensity_array = np.array(tsf_data.read_profile_spectrum(frame), dtype=encoding_dtype)
+        index_buf, intensity_array = tsf_data.read_profile_spectrum(frame)
+        intensity_array = np.array(intensity_array, dtype=encoding_dtype)
         mz_array = tsf_data.index_to_mz(frame, index_buf)
         mz_acq_range_lower = float(mz_array[0])
         mz_acq_range_upper = float(mz_array[-1])

--- a/timsconvert/parse_maldi.py
+++ b/timsconvert/parse_maldi.py
@@ -30,9 +30,9 @@ def extract_maldi_tsf_spectrum_arrays(tsf_data, mode, frame, profile_bins, encod
         index_buf, intensity_array = tsf_data.read_profile_spectrum(frame)
         intensity_array = np.array(intensity_array, dtype=encoding_dtype)
         mz_array = tsf_data.index_to_mz(frame, index_buf)
-        mz_acq_range_lower = float(mz_array[0])
-        mz_acq_range_upper = float(mz_array[-1])
         if profile_bins != 0:
+            mz_acq_range_lower = float(mz_array[0])
+            mz_acq_range_upper = float(mz_array[-1])
             bins = np.linspace(mz_acq_range_lower, mz_acq_range_upper, profile_bins, dtype=encoding_dtype)
             unique_indices, inverse_indices = np.unique(np.digitize(mz_array, bins), return_inverse=True)
             bin_counts = np.bincount(inverse_indices)
@@ -63,12 +63,12 @@ def extract_maldi_tdf_spectrum_arrays(tdf_data, mode, multiscan, frame, scan_beg
             mz_array, intensity_array = tdf_data.extract_spectrum_for_frame_v2(frame, scan_begin, scan_end, encoding)
             return mz_array, intensity_array
     elif mode == 'profile':
-        intensity_array = np.array(tdf_data.extract_profile_spectrum_for_frame(frame, scan_begin, scan_end),
-                                   dtype=encoding_dtype)
-        mz_acq_range_lower = float(tdf_data.meta_data['MzAcqRangeLower'])
-        mz_acq_range_upper = float(tdf_data.meta_data['MzAcqRangeUpper'])
-        mz_array = np.linspace(mz_acq_range_lower, mz_acq_range_upper, len(intensity_array), dtype=encoding_dtype)
+        index_buf, intensity_array = tdf_data.extract_profile_spectrum_for_frame(frame, scan_begin, scan_end)
+        intensity_array = np.array(intensity_array, dtype=encoding_dtype)
+        mz_array = tdf_data.index_to_mz(frame, index_buf)
         if profile_bins != 0:
+            mz_acq_range_lower = float(mz_array[0])
+            mz_acq_range_upper = float(mz_array[-1])
             bins = np.linspace(mz_acq_range_lower, mz_acq_range_upper, profile_bins, dtype=encoding_dtype)
             unique_indices, inverse_indices = np.unique(np.digitize(mz_array, bins), return_inverse=True)
             bin_counts = np.bincount(inverse_indices)

--- a/timsconvert/parse_maldi.py
+++ b/timsconvert/parse_maldi.py
@@ -27,10 +27,10 @@ def extract_maldi_tsf_spectrum_arrays(tsf_data, mode, frame, profile_bins, encod
         mz_array = tsf_data.index_to_mz(frame, index_buf)
         return mz_array, intensity_array
     elif mode == 'profile':
-        intensity_array = np.array(tsf_data.read_profile_spectrum(frame), dtype=encoding_dtype)
-        mz_acq_range_lower = float(tsf_data.meta_data['MzAcqRangeLower'])
-        mz_acq_range_upper = float(tsf_data.meta_data['MzAcqRangeUpper'])
-        mz_array = np.linspace(mz_acq_range_lower, mz_acq_range_upper, len(intensity_array), dtype=encoding_dtype)
+        index_buf, intensity_array = np.array(tsf_data.read_profile_spectrum(frame), dtype=encoding_dtype)
+        mz_array = tsf_data.index_to_mz(frame, index_buf)
+        mz_acq_range_lower = float(mz_array[0])
+        mz_acq_range_upper = float(mz_array[-1])
         if profile_bins != 0:
             bins = np.linspace(mz_acq_range_lower, mz_acq_range_upper, profile_bins, dtype=encoding_dtype)
             unique_indices, inverse_indices = np.unique(np.digitize(mz_array, bins), return_inverse=True)

--- a/timsconvert/parse_maldi.py
+++ b/timsconvert/parse_maldi.py
@@ -193,8 +193,6 @@ def parse_maldi_tdf(tdf_data, frame_start, frame_stop, mode, ms2_only, exclude_m
     if mode == 'profile':
         centroided = False
         exclude_mobility = True
-        logging.info(get_timestamp() + ':' + 'Export of ion mobility data is not supported for profile mode data...')
-        logging.info(get_timestamp() + ':' + 'Exporting without ion mobility data...')
     elif mode == 'centroid' or mode == 'raw':
         centroided = True
 

--- a/timsconvert/write_maldi_ims.py
+++ b/timsconvert/write_maldi_ims.py
@@ -82,6 +82,9 @@ def write_maldi_ims_imzml(data, outdir, outfile, mode, exclude_mobility, profile
     elif data.meta_data['SchemaType'] == 'TDF':
         if mode == 'profile':
             exclude_mobility = True
+            logging.info(
+                get_timestamp() + ':' + 'Export of ion mobility data is not supported for profile mode data...')
+            logging.info(get_timestamp() + ':' + 'Exporting without ion mobility data...')
         if exclude_mobility == False:
             writer = ImzMLWriter(os.path.join(outdir, outfile),
                                  polarity=polarity,

--- a/timsconvert/write_maldi_ims.py
+++ b/timsconvert/write_maldi_ims.py
@@ -18,6 +18,8 @@ def write_maldi_ims_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mo
                                    scan_dict['intensity_array'],
                                    scan_dict['coord'])
     elif data.meta_data['SchemaType'] == 'TDF':
+        if mode == 'profile':
+            exclude_mobility = True
         if exclude_mobility == False:
             for scan_dict in list_of_scan_dicts:
                 imzml_file.addSpectrum(scan_dict['mz_array'],
@@ -78,6 +80,8 @@ def write_maldi_ims_imzml(data, outdir, outfile, mode, exclude_mobility, profile
                              intensity_compression=compression_object,
                              include_mobility=False)
     elif data.meta_data['SchemaType'] == 'TDF':
+        if mode == 'profile':
+            exclude_mobility = True
         if exclude_mobility == False:
             writer = ImzMLWriter(os.path.join(outdir, outfile),
                                  polarity=polarity,


### PR DESCRIPTION
Add support for profile data in mzML and imzML formats for all acquisition modes. Ion mobility arrays are omitted by hardcoding for now due to resulting data size/conversion time. Will include by request if necessary for certain use cases.