### PR TITLE
Fix update_spectra_count

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='timsconvert',
-    version='1.0.0',
+    version='1.0.1',
     packages=['timsconvert'],
     url='https://github.com/gtluu/timsconvert',
     license='Apache License',

--- a/tdf2mzml/tdf2mzml.py
+++ b/tdf2mzml/tdf2mzml.py
@@ -1159,8 +1159,12 @@ def tdf2mzml_write_mzml(args):
 
                     #     scan_progress(mzml_data_struct)
 
-        logging.info("Writing final mzML")
-        update_spectra_count(args['outdir'], args['outfile'], mzml_data_struct['scan_index'] - 1)
+        if total_spectra_count != mzml_data_struct['scan_index']-1:
+            logging.info('Updating scan count...')
+            update_spectra_count(
+                args['outdir'], args['outfile'], mzml_data_struct['scan_index'] - 1)
+        logging.info('Finished writing to .mzML file ' +
+                     os.path.join(args['outdir'], args['outfile']) + '...')
 
     return
 

--- a/tdf2mzml/tdf2mzml.py
+++ b/tdf2mzml/tdf2mzml.py
@@ -1159,12 +1159,12 @@ def tdf2mzml_write_mzml(args):
 
                     #     scan_progress(mzml_data_struct)
 
-        if total_spectra_count != mzml_data_struct['scan_index']-1:
-            logging.info('Updating scan count...')
-            update_spectra_count(
-                args['outdir'], args['outfile'], mzml_data_struct['scan_index'] - 1)
-        logging.info('Finished writing to .mzML file ' +
-                     os.path.join(args['outdir'], args['outfile']) + '...')
+    if total_spectra_count != mzml_data_struct['scan_index']-1:
+        logging.info('Updating scan count...')
+        update_spectra_count(
+            args['outdir'], args['outfile'], mzml_data_struct['scan_index'] - 1)
+    logging.info('Finished writing to .mzML file ' +
+                 os.path.join(args['outdir'], args['outfile']) + '...')
 
     return
 

--- a/timsconvert/write_lcms.py
+++ b/timsconvert/write_lcms.py
@@ -181,6 +181,9 @@ def write_lcms_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_mobil
                         scan_count = write_lcms_chunk_to_mzml(data, writer, frame_start, frame_stop, scan_count, mode,
                                                               ms2_only, exclude_mobility, profile_bins, encoding,
                                                               compression)
-    logging.info(get_timestamp() + ':' + 'Updating scan count...')
-    update_spectra_count(outdir, outfile, scan_count)
-    logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' + os.path.join(outdir, outfile) + '...')
+
+    if num_of_spectra != scan_count:
+        logging.info(get_timestamp() + ':' + 'Updating scan count...')
+        update_spectra_count(outdir, outfile, scan_count)
+    logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' +
+                 os.path.join(outdir, outfile) + '...')

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -86,4 +86,3 @@ def update_spectra_count(outdir, outfile, scan_count):
     ns = mzml.tag[:mzml.tag.find('}') + 1]
     mzml.find('.//' + ns + 'spectrumList').set('count', str(scan_count).encode('utf-8'))
     mzml_tree.write(os.path.join(outdir, outfile), encoding='utf-8', xml_declaration=True)
-    mzml_tree.close()

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -86,4 +86,4 @@ def update_spectra_count(outdir, outfile, scan_count):
     ns = mzml.tag[:mzml.tag.find('}') + 1]
     mzml.find('.//' + ns + 'spectrumList').set('count', str(scan_count).encode('utf-8'))
     mzml_tree.write(os.path.join(outdir, outfile), encoding='utf-8', xml_declaration=True)
-	mzml_tree.close()
+    mzml_tree.close()

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -86,3 +86,4 @@ def update_spectra_count(outdir, outfile, scan_count):
     ns = mzml.tag[:mzml.tag.find('}') + 1]
     mzml.find('.//' + ns + 'spectrumList').set('count', str(scan_count).encode('utf-8'))
     mzml_tree.write(os.path.join(outdir, outfile), encoding='utf-8', xml_declaration=True)
+	mzml_tree.close()


### PR DESCRIPTION
In tdf2mzml.py, `update_spectra_count` was invoked inside `with mzml_data_struct['writer']:`.
It needs to be invoked after MzMLWriter is flushed/closed.

I optimized the code to only invoke update_spectra_count when spectra_count has changed.