### PR TITLE
Spectrum metadata

### DIFF
--- a/timsconvert/write_lcms.py
+++ b/timsconvert/write_lcms.py
@@ -183,5 +183,5 @@ def write_lcms_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_mobil
                                                               ms2_only, exclude_mobility, profile_bins, encoding,
                                                               compression)
     logging.info(get_timestamp() + ':' + 'Updating scan count...')
-    update_spectra_count(outdir, outfile, scan_count)
+    update_spectra_count(outdir, outfile, num_of_spectra, scan_count)
     logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' + os.path.join(outdir, outfile) + '...')

--- a/timsconvert/write_lcms.py
+++ b/timsconvert/write_lcms.py
@@ -140,7 +140,8 @@ def write_lcms_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_mobil
                     compression, barebones_metadata, chunk_size):
     # Initialize mzML writer using psims.
     logging.info(get_timestamp() + ':' + 'Initializing mzML Writer...')
-    writer = MzMLWriter(os.path.join(outdir, outfile), close=True)
+    #writer = MzMLWriter(os.path.join(outdir, outfile), close=True)
+    writer = MzMLWriter(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML', close=True)
 
     with writer:
         # Begin mzML with controlled vocabularies (CV).

--- a/timsconvert/write_lcms.py
+++ b/timsconvert/write_lcms.py
@@ -78,7 +78,7 @@ def write_lcms_ms2_spectrum(writer, parent_scan, encoding, product_scan, compres
         precursor_info['params'].append({'inverse reduced ion mobility': product_scan['selected_ion_mobility']})
     if 'selected_ion_ccs' in product_scan.keys():
         precursor_info['params'].append({'collisional cross sectional area': product_scan['selected_ion_ccs']})
-    if not np.isnan(product_scan['charge_state']):
+    if not np.isnan(product_scan['charge_state']) and int(product_scan['charge_state']) != 0:
         precursor_info['charge'] = product_scan['charge_state']
 
     if parent_scan != None:

--- a/timsconvert/write_maldi_dd.py
+++ b/timsconvert/write_maldi_dd.py
@@ -6,7 +6,7 @@ import numpy as np
 from psims.mzml import MzMLWriter
 
 
-def write_maldi_dd_ms1_spectrum(writer, data, scan, encoding, compression):
+def write_maldi_dd_ms1_spectrum(writer, data, scan, encoding, compression, title=None):
     # Build params.
     params = [scan['scan_type'],
               {'ms level': scan['ms_level']},
@@ -15,7 +15,8 @@ def write_maldi_dd_ms1_spectrum(writer, data, scan, encoding, compression):
               {'base peak intensity': scan['base_peak_intensity']},
               {'highest observed m/z': scan['high_mz']},
               {'lowest observed m/z': scan['low_mz']},
-              {'maldi spot identifier': scan['coord']}]
+              {'maldi spot identifier': scan['coord']},
+              {'spectrum title': title}]
 
     if data.meta_data['SchemaType'] == 'TDF' and scan['ms_level'] == 1 and scan['mobility_array'] is not None:
         # This version only works with newer versions of psims.
@@ -51,11 +52,12 @@ def write_maldi_dd_ms1_spectrum(writer, data, scan, encoding, compression):
                           compression=compression)
 
 
-def write_maldi_dd_ms2_spectrum(writer, scan, encoding, compression):
+def write_maldi_dd_ms2_spectrum(writer, scan, encoding, compression, title=None):
     # Build params.
     params = [scan['scan_type'],
               {'ms level': scan['ms_level']},
-              {'total ion current': scan['total_ion_current']}]
+              {'total ion current': scan['total_ion_current']},
+              {'spectrum title': title}]
     if 'base_peak_mz' in scan.keys() and 'base_peak_intensity' in scan.keys():
         params.append({'base peak m/z': scan['base_peak_mz']})
         params.append({'base peak intensity': scan['base_peak_intensity']})
@@ -140,9 +142,11 @@ def write_maldi_dd_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_m
                             scan_count += 1
                             scan_dict['scan_number'] = scan_count
                             if scan_dict['ms_level'] == 1:
-                                write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression)
+                                write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression,
+                                                            title=os.path.splitext(outfile)[0])
                             elif scan_dict['ms_level'] == 2:
-                                write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression)
+                                write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression,
+                                                            title=os.path.splitext(outfile)[0])
 
         logging.info(get_timestamp() + ':' + 'Updating scan count...')
         update_spectra_count(outdir, outfile, num_of_spectra, scan_count)
@@ -187,9 +191,11 @@ def write_maldi_dd_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_m
                                 pass
                             else:
                                 if scan_dict['ms_level'] == 1:
-                                    write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression)
+                                    write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression,
+                                                                title=plate_map_dict[scan_dict['coord']])
                                 elif scan_dict['ms_level'] == 2:
-                                    write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression)
+                                    write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression,
+                                                                title=plate_map_dict[scan_dict['coord']])
                 logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' +
                              os.path.join(outdir, output_filename) + '...')
     elif maldi_output_file == 'sample' and plate_map != '':
@@ -247,9 +253,11 @@ def write_maldi_dd_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_m
                                         scan_count += 1
                                         scan_dict['scan_number'] = scan_count
                                         if scan_dict['ms_level'] == 1:
-                                            write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression)
+                                            write_maldi_dd_ms1_spectrum(writer, data, scan_dict, encoding, compression,
+                                                                        title=key)
                                         elif scan_dict['ms_level'] == 2:
-                                            write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression)
+                                            write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression,
+                                                                        title=key)
 
                     logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' +
                                  os.path.join(outdir, outfile) + '...')

--- a/timsconvert/write_maldi_dd.py
+++ b/timsconvert/write_maldi_dd.py
@@ -98,7 +98,8 @@ def write_maldi_dd_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_m
     if maldi_output_file == 'combined':
         # Initialize mzML writer using psims.
         logging.info(get_timestamp() + ':' + 'Initializing mzML Writer...')
-        writer = MzMLWriter(os.path.join(outdir, outfile), close=True)
+        #writer = MzMLWriter(os.path.join(outdir, outfile), close=True)
+        writer = MzMLWriter(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML', close=True)
 
         with writer:
             # Begin mzML with controlled vocabularies (CV).

--- a/timsconvert/write_maldi_dd.py
+++ b/timsconvert/write_maldi_dd.py
@@ -145,7 +145,7 @@ def write_maldi_dd_mzml(data, infile, outdir, outfile, mode, ms2_only, exclude_m
                                 write_maldi_dd_ms2_spectrum(writer, scan_dict, encoding, compression)
 
         logging.info(get_timestamp() + ':' + 'Updating scan count...')
-        update_spectra_count(outdir, outfile, scan_count)
+        update_spectra_count(outdir, outfile, num_of_spectra, scan_count)
         logging.info(get_timestamp() + ':' + 'Finished writing to .mzML file ' + os.path.join(outdir, outfile) + '...')
     elif maldi_output_file == 'individual' and plate_map != '':
         # Check to make sure plate map is a valid csv file.

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -79,10 +79,10 @@ def get_spectra_count(data):
     return ms1_count + ms2_count
 
 
-def update_spectra_count(outdir, outfile, scan_count):
+def update_spectra_count(outdir, outfile, num_of_spectra, scan_count):
     with open(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML', 'r') as in_stream, \
             open(os.path.join(outdir, outfile), 'w') as out_stream:
         for line in in_stream:
-            out_stream.write(line.replace('      <spectrumList count="1000" defaultDataProcessingRef="exportation">',
+            out_stream.write(line.replace('      <spectrumList count="' + str(num_of_spectra) + '" defaultDataProcessingRef="exportation">',
                                           '      <spectrumList count="' + str(scan_count) + '" defaultDataProcessingRef="exportation">'))
     os.remove(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML')

--- a/timsconvert/write_mzml.py
+++ b/timsconvert/write_mzml.py
@@ -80,9 +80,9 @@ def get_spectra_count(data):
 
 
 def update_spectra_count(outdir, outfile, scan_count):
-    huge_parser = XMLParser(huge_tree=True)
-    mzml_tree = parse(os.path.join(outdir, outfile), parser=huge_parser)
-    mzml = mzml_tree.getroot()
-    ns = mzml.tag[:mzml.tag.find('}') + 1]
-    mzml.find('.//' + ns + 'spectrumList').set('count', str(scan_count).encode('utf-8'))
-    mzml_tree.write(os.path.join(outdir, outfile), encoding='utf-8', xml_declaration=True)
+    with open(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML', 'r') as in_stream, \
+            open(os.path.join(outdir, outfile), 'w') as out_stream:
+        for line in in_stream:
+            out_stream.write(line.replace('      <spectrumList count="1000" defaultDataProcessingRef="exportation">',
+                                          '      <spectrumList count="' + str(scan_count) + '" defaultDataProcessingRef="exportation">'))
+    os.remove(os.path.splitext(os.path.join(outdir, outfile))[0] + '_tmp.mzML')


### PR DESCRIPTION
updates various spectrum metadata and improves update_spectra_count to use a stream to count spectra instead of re-reading and parsing the entire mzml file