### PR TITLE
Added retention time to coordinates for nano-DESI mode

### DIFF
--- a/bin/nanodesi.py
+++ b/bin/nanodesi.py
@@ -5,7 +5,7 @@ from timsconvert.constants import VERSION
 from timsconvert.data_input import dot_d_detection
 from timsconvert.timestamp import get_iso8601_timestamp
 from timsconvert_nanodesi.arguments import get_args, args_check
-from timsconvert_nanodesi.convert import convert_raw_file, clean_up_logfiles
+from timsconvert_nanodesi.convert import convert_raw_file, clean_up_logfiles, get_frame_id_for_each_coordinate
 
 
 def main():
@@ -28,9 +28,12 @@ def main():
                 logging.info(get_iso8601_timestamp() + ':' + f'{dirpath} does not exist...')
                 logging.info(get_iso8601_timestamp() + ':' + 'Skipping...')
 
-    # Convert each sample.
+    # Get number of scans per line for interpolation.
+    frame_ids_at_each_coord = get_frame_id_for_each_coordinate(input_files, args)
+
+    # Convert each sample
     with Pool(processes=cpu_count() - 1) as pool:
-        pool_map_input = [(args, infile) for infile in input_files]
+        pool_map_input = [(args, infile, line_number+1, frame_ids_at_each_coord[line_number]) for line_number, infile in enumerate(input_files)]
         list_of_logfiles = pool.map(convert_raw_file, pool_map_input)
     list_of_logfiles = list(filter(None, list_of_logfiles))
 

--- a/timsconvert_nanodesi/arguments.py
+++ b/timsconvert_nanodesi/arguments.py
@@ -118,3 +118,8 @@ def args_check(args):
     # Check if output directory exists and create it if it does not.
     if not os.path.isdir(args['outdir']) and args['outdir'] != '':
         os.makedirs(args['outdir'])
+
+    # Check that the user defines the number of scans per line if scans_per_line is set to user_defined
+    if args["scans_per_line"] == "user_defined":
+        if args["scans_per_line_value"] == 0:
+            raise ValueError("User defined scans per line value must be greater than 0.")

--- a/timsconvert_nanodesi/arguments.py
+++ b/timsconvert_nanodesi/arguments.py
@@ -87,12 +87,12 @@ def get_args():
     # Can be minimum, maximum, or mean number of scans per line-scan or a user defined number of scans per line.
     # TODO: Add arg_descriptions for these parameters
     optional.add_argument('--scans_per_line',
-                            help=arg_descriptions['scans_per_line'],
+                            help="The method used for determining how to determine the number of pixels to use in the scanning direction. Can be \"minimum\", \"maximum\", \"mean\", or \"user_defined\". Defaults to \"mean\"",#arg_descriptions['scans_per_line'],
                             default='mean',
                             type=str,
                             choices=['minimum', 'maximum', 'mean', 'user_defined'])
     optional.add_argument('--scans_per_line_value', 
-                            help=arg_descriptions['scans_per_line_value'],
+                            help="The integer number of pixels to use in the scanning direction if scans_per_line is set to \"user_defined\"",#arg_descriptions['scans_per_line_value'],
                             default=0,
                             type=int)
 

--- a/timsconvert_nanodesi/arguments.py
+++ b/timsconvert_nanodesi/arguments.py
@@ -83,6 +83,18 @@ def get_args():
                           default='processed',
                           type=str,
                           choices=['processed', 'continuous'])
+    # add another argument for how to handle number of scans per file:
+    # Can be minimum, maximum, or mean number of scans per line-scan or a user defined number of scans per line.
+    # TODO: Add arg_descriptions for these parameters
+    optional.add_argument('--scans_per_line',
+                            help=arg_descriptions['scans_per_line'],
+                            default='mean',
+                            type=str,
+                            choices=['minimum', 'maximum', 'mean', 'user_defined'])
+    optional.add_argument('--scans_per_line_value', 
+                            help=arg_descriptions['scans_per_line_value'],
+                            default=0,
+                            type=int)
 
     # System Arguments
     system = parser.add_argument_group('System Parameters')

--- a/timsconvert_nanodesi/convert.py
+++ b/timsconvert_nanodesi/convert.py
@@ -94,6 +94,8 @@ def get_frame_id_for_each_coordinate(input_files, run_args):
 def convert_raw_file(tuple_args):
     run_args = tuple_args[0]
     infile = tuple_args[1]
+    line_number = tuple_args[2]
+    frame_ids_at_each_coord = tuple_args[3]
     # Set output directory to default if not specified.
     if run_args['outdir'] == '':
         run_args['outdir'] = os.path.split(infile)[0]
@@ -181,6 +183,8 @@ def convert_raw_file(tuple_args):
                          intensity_encoding=run_args['intensity_encoding'],
                          mobility_encoding=run_args['mobility_encoding'],
                          compression=run_args['compression'],
+                         line_number=line_number,
+                         frame_id_for_each_coord=frame_ids_at_each_coord,
                          chunk_size=10)
 
     logging.info('\n')

--- a/timsconvert_nanodesi/convert.py
+++ b/timsconvert_nanodesi/convert.py
@@ -9,7 +9,88 @@ from pyTDFSDK.init_tdf_sdk import init_tdf_sdk_api
 from pyTDFSDK.ctypes_data_structures import PressureCompensationStrategy
 from pyBaf2Sql.init_baf2sql import init_baf2sql_api
 
+# Gets the info needed to get coordinants from retention times.
+def get_frame_id_for_each_coordinate(input_files, run_args):
+    tdf_sdk_dll = init_tdf_sdk_api()
+    baf2sql_dll = init_baf2sql_api()
 
+    scan_time_extremes = [None] * len(input_files)
+    scans_per_line = [None] * len(input_files)
+    scan_ids_per_line = [None] * len(input_files)
+    scan_times_per_line = [None] * len(input_files)
+    for i, infile in enumerate(input_files):
+        if not check_for_multiple_analysis(infile):
+            schema = schema_detection(infile)
+
+            if schema == 'TSF':
+                data = TimsconvertTsfData(infile, tdf_sdk_dll, use_recalibrated_state=use_recalibrated_state)
+            elif schema == 'TDF':
+                if run_args['use_raw_calibration']:
+                    use_recalibrated_state = False
+                elif not run_args['use_raw_calibration']:
+                    use_recalibrated_state = True
+                if run_args['pressure_compensation_strategy'] == 'none':
+                    pressure_compensation_strategy = PressureCompensationStrategy.NoPressureCompensation
+                elif run_args['pressure_compensation_strategy'] == 'global':
+                    pressure_compensation_strategy = PressureCompensationStrategy.AnalyisGlobalPressureCompensation
+                elif run_args['pressure_compensation_strategy'] == 'frame':
+                    pressure_compensation_strategy = PressureCompensationStrategy.PerFramePressureCompensation
+                data = TimsconvertTdfData(infile,
+                                        tdf_sdk_dll,
+                                        use_recalibrated_state=use_recalibrated_state,
+                                        pressure_compensation_strategy=pressure_compensation_strategy)
+            elif schema == 'BAF':
+                if run_args['use_raw_calibration']:
+                    raw_calibration = True
+                elif not run_args['use_raw_calibration']:
+                    raw_calibration = False
+                data = TimsconvertBafData(infile, baf2sql_dll, raw_calibration=raw_calibration)
+            
+            # Get the number of scans per line and scan time
+            frames = data.analysis["Frames"]
+            scan_id = frames["Id"].to_list()
+            scan_times = frames["Time"].to_list()
+            scan_time_extremes[i] = min(scan_times), max(scan_times)
+
+            # TODO: Make sure this will work properly. 
+            # Currently it doesn't differentiate different MSMS scan types.
+            if run_args["ms2_only"]:
+                ms2_frames = frames[frames["MsMsType"] != 0]
+                scan_id = ms2_frames["Id"].to_list()
+                scan_times = ms2_frames["Time"].to_list()
+
+            scan_ids_per_line[i] = scan_id
+            scan_times_per_line[i] = scan_times
+            scans_per_line[i] = len(scan_times)
+
+        else:
+            return
+    
+    if run_args['scans_per_line'] == 'minimum':
+        scans_per_line = min(scans_per_line)
+    elif run_args['scans_per_line'] == 'maximum':
+        scans_per_line = max(scans_per_line)
+    elif run_args['scans_per_line'] == 'mean':
+        scans_per_line = round(sum(scans_per_line) / len(scans_per_line))
+    elif run_args['scans_per_line'] == 'user_defined':
+        scans_per_line = run_args['scans_per_line_value']
+
+    # Use nearest neighbor interpolation to get the scan id for each coordinate.
+    frame_ids_at_each_coord = []
+    for line_idx in range(len(scan_times_per_line)):
+        a, b = scan_time_extremes[line_idx]
+        points_to_sample_at = [a+j*(b-a)/scans_per_line for j in range(scans_per_line)]
+        X = scan_times_per_line[i]
+        Y = scan_ids_per_line[i]
+
+        # 1d nearest neighbor interpolation of scan times, with the frame IDs as the output values.
+        frame_ids_at_each_coord.append([Y[min(range(len(X)), key=lambda j: abs(X[j] - xr))] for xr in points_to_sample_at])
+
+    return frame_ids_at_each_coord
+
+
+# TODO: Currently, I think this function outputs a separate imzML file 
+#       for each input file rather than all writing to the same one.
 def convert_raw_file(tuple_args):
     run_args = tuple_args[0]
     infile = tuple_args[1]

--- a/timsconvert_nanodesi/write.py
+++ b/timsconvert_nanodesi/write.py
@@ -71,8 +71,6 @@ def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mod
                                                      mz_encoding,
                                                      intensity_encoding,
                                                      mobility_encoding)
-        # TODO: Emerson: convert retention time to x-y coord
-        # implementation of interpolate_to_determine_pixel_locations method?
         if mode == 'profile':
             exclude_mobility = True
         if not exclude_mobility:

--- a/timsconvert_nanodesi/write.py
+++ b/timsconvert_nanodesi/write.py
@@ -6,10 +6,11 @@ import logging
 from pyimzml.ImzMLWriter import ImzMLWriter
 from pyimzml.compression import NoCompression, ZlibCompression
 from pyTDFSDK.util import get_encoding_dtype
-
+# TODO: Emerson: Need to load all input files in order to get all retention times first.
+# This lets us get a mask of where to assign spectra for each scan, which aligns spectra spatially.
 
 def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mode, exclude_mobility, profile_bins,
-                                  mz_encoding, intensity_encoding, mobility_encoding):
+                                  mz_encoding, intensity_encoding, mobility_encoding, line_number, frame_id_for_each_coord):
     """
     Parse and write out a group of spectra to an imzML file from a nano-DESI timsTOF fleX MSI dataset using pyimzML.
 
@@ -33,6 +34,10 @@ def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mod
     :type intensity_encoding: int
     :param mobility_encoding: Mobility encoding command line parameter, either "64" or "32".
     :type mobility_encoding: int
+    :param line_number: Line number of the input file.
+    :type line_number: int
+    :param frame_id_for_each_coord: list containing frame IDs for each coordinate.
+    :type frame_id_for_each_coord: list
     """
     # Parse and write TSF data.
     if isinstance(data, TimsconvertTsfData):
@@ -44,12 +49,16 @@ def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mod
                                                      profile_bins,
                                                      mz_encoding,
                                                      intensity_encoding)
-        # TODO: Emerson: convert retention time to x-y coord
-        # implementation of interpolate_to_determine_pixel_locations method?
-        for scans in parent_scans:
-            imzml_file.addSpectrum(scans.mz_array,
-                                   scans.intensity_array,
-                                   scans.coord)
+        # TODO: Test this. It uses a list containing the frame ID to be used in each coordinate.
+        for i, scans in parent_scans:
+            frame_id = i+frame_start
+            # Get index values where frame_id matches the frame_id_for_each_coord list.
+            frame_id_matches = [idx for idx, x in enumerate(frame_id_for_each_coord) if x == frame_id]
+            for idx in frame_id_matches:
+                coord = (line_number, idx)
+                imzml_file.addSpectrum(scans.mz_array,
+                                       scans.intensity_array,
+                                       coord)
     # Parse and write TDF data.
     elif isinstance(data, TimsconvertTdfData):
         parent_scans, product_scans = parse_lcms_tdf(data,
@@ -67,16 +76,28 @@ def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mod
         if mode == 'profile':
             exclude_mobility = True
         if not exclude_mobility:
-            for scans in parent_scans:
-                imzml_file.addSpectrum(scans.mz_array,
-                                       scans.intensity_array,
-                                       scans.coord,
-                                       mobilities=scans.mobility_array)
+            # TODO: Test this. It uses a list containing the frame ID to be used in each coordinate.
+            for i, scans in parent_scans:
+                frame_id = i+frame_start
+                # Get index values where frame_id matches the frame_id_for_each_coord list.
+                frame_id_matches = [idx for idx, x in enumerate(frame_id_for_each_coord) if x == frame_id]
+                for idx in frame_id_matches:
+                    coord = (line_number, idx)
+                    imzml_file.addSpectrum(scans.mz_array,
+                                        scans.intensity_array,
+                                        coord,
+                                        mobilities=scans.mobility_array)
         elif exclude_mobility:
-            for scans in parent_scans:
-                imzml_file.addSpectrum(scans.mz_array,
-                                       scans.intensity_array,
-                                       scans.coord)
+            # TODO: Test this. It uses a list containing the frame ID to be used in each coordinate.
+            for i, scans in parent_scans:
+                frame_id = i+frame_start
+                # Get index values where frame_id matches the frame_id_for_each_coord list.
+                frame_id_matches = [idx for idx, x in enumerate(frame_id_for_each_coord) if x == frame_id]
+                for idx in frame_id_matches:
+                    coord = (line_number, idx)
+                    imzml_file.addSpectrum(scans.mz_array,
+                                        scans.intensity_array,
+                                        coord)
     # Parse and write BAF data.
     elif isinstance(data, TimsconvertBafData):
         parent_scans, product_scans = parse_lcms_baf(data,
@@ -87,16 +108,22 @@ def write_nanodesi_chunk_to_imzml(data, imzml_file, frame_start, frame_stop, mod
                                                      profile_bins,
                                                      mz_encoding,
                                                      intensity_encoding)
-        # TODO: Emerson: convert retention time to x-y coord
-        # implementation of interpolate_to_determine_pixel_locations method?
-        for scans in parent_scans:
-            imzml_file.addSpectrum(scans.mz_array,
-                                   scans.intensity_array,
-                                   scans.coord)
+        # TODO: Test this. It uses a list containing the frame ID to be used in each coordinate.
+        for i, scans in parent_scans:
+            frame_id = i+frame_start
+            # Get index values where frame_id matches the frame_id_for_each_coord list.
+            frame_id_matches = [idx for idx, x in enumerate(frame_id_for_each_coord) if x == frame_id]
+            for idx in frame_id_matches:
+                coord = (line_number, idx)
+                imzml_file.addSpectrum(scans.mz_array,
+                                    scans.intensity_array,
+                                    coord,
+                                    mobilities=scans.mobility_array)
+
 
 
 def write_nanodesi_imzml(data, outdir, outfile, mode, exclude_mobility, profile_bins, imzml_mode, mz_encoding,
-                         intensity_encoding, mobility_encoding, compression, chunk_size=10):
+                         intensity_encoding, mobility_encoding, compression, line_number, frame_id_for_each_coord, chunk_size=10):
     """
     Parse and write out spectra to an imzML file from a nano-DESI timsTOF fleX MSI dataset using pyimzML.
 
@@ -211,7 +238,9 @@ def write_nanodesi_imzml(data, outdir, outfile, mode, exclude_mobility, profile_
                                               profile_bins,
                                               mz_encoding,
                                               intensity_encoding,
-                                              mobility_encoding)
+                                              mobility_encoding,
+                                              line_number, 
+                                              frame_id_for_each_coord)
                 sys.stdout.write(get_iso8601_timestamp() +
                                  ':' +
                                  data.source_file.replace('/', '\\') +
@@ -241,7 +270,9 @@ def write_nanodesi_imzml(data, outdir, outfile, mode, exclude_mobility, profile_
                                               profile_bins,
                                               mz_encoding,
                                               intensity_encoding,
-                                              mobility_encoding)
+                                              mobility_encoding,
+                                              line_number, 
+                                              frame_id_for_each_coord)
                 sys.stdout.write(get_iso8601_timestamp() +
                                  ':' +
                                  data.source_file.replace('/', '\\') +


### PR DESCRIPTION
Added support for determining x,y coordinates from the retention times in nano-DESI line scans.

To do this, all line scans are opened and the retention time of each frame is recorded. The minimum, maximum, or mean number of frames per line scan is used to determine the number of pixels that will be be used in the x-dimension of the image. Alternatively, the user can manually define this number. Then, nearest-neighbor interpolation is used to resample each line at uniformly distributed retention times within the retention time range, with the output being a list of lists containing the frame ID that will be used at each coordinate in the output imzML file. The line number and the its corresponding frame ID list are now provided to the pool_map to identify which frames are to be used at which coordinates. 

This involved adding two new arguments: scans_per_line (the method used to determine the number of pixels in the x-direction, being minimum, maximum, mean, or user_defined) and scans_per_line_value (the value if scans_per_line is "user_defined". These may be renamed to improve clarity.

I am unfamiliar with how timsconvert is tested for bugs, so I recommend testing the changes before merging. 